### PR TITLE
allow webm video files to play using videojs-ogvjs

### DIFF
--- a/iOS/Controller/Tab/WebKitWebController.swift
+++ b/iOS/Controller/Tab/WebKitWebController.swift
@@ -17,6 +17,7 @@ class WebKitWebController: UIViewController, WKUIDelegate, WKNavigationDelegate,
     private let webView: WKWebView = {
         let config = WKWebViewConfiguration()
         config.setURLSchemeHandler(KiwixURLSchemeHandler(), forURLScheme: "kiwix")
+        config.mediaTypesRequiringUserActionForPlayback = []
         return WKWebView(frame: .zero, configuration: config)
     }()
     weak var delegate: WebViewControllerDelegate?


### PR DESCRIPTION
As there is no native support for webm in Webkit, we use a JS implementation
of the codec, called using video.js.

the mechanism is use fails to be detected by webkit as a "user-initiated play" resulting
in webm videos to be paused immediately on play.

To overcome this, we allow all media files to be played without user action.
> previous youtube ZIM files had autoplay enabled.