### PR TITLE
safer library list update

### DIFF
--- a/iOS/Controller/Library/LibraryCategoryController.swift
+++ b/iOS/Controller/Library/LibraryCategoryController.swift
@@ -123,8 +123,11 @@ class LibraryCategoryController: UIViewController, UITableViewDataSource, UITabl
                 switch changes {
                 case .initial:
                     self.tableView.reloadSections([sectionIndex], with: .none)
-                case .update(_, let deletions, let insertions, _):
-                    if !deletions.isEmpty || !insertions.isEmpty {
+                case .update(_, let deletions, let insertions, let updates):
+                    if deletions.isEmpty, insertions.isEmpty {
+                        let indexPaths = updates.map { IndexPath(row: $0, section: sectionIndex) }
+                        self.tableView.reloadRows(at: indexPaths, with: .automatic)
+                    } else {
                         self.tableView.reloadSections([sectionIndex], with: .automatic)
                     }
                 default:

--- a/iOS/Controller/Library/LibraryMasterController.swift
+++ b/iOS/Controller/Library/LibraryMasterController.swift
@@ -57,7 +57,7 @@ class LibraryMasterController: UIViewController, UIDocumentPickerDelegate, UITab
         tableView.register(TableViewCell.self, forCellReuseIdentifier: "Cell")
         tableView.register(TableViewCell.self, forCellReuseIdentifier: "CategoryCell")
         tableView.separatorInsetReference = .fromAutomaticInsets
-        tableView.separatorInset = UIEdgeInsets(top: 0, left: 40, bottom: 0, right: 0)
+        tableView.separatorInset = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 0)
     }
 
     override func viewDidLoad() {
@@ -176,19 +176,19 @@ class LibraryMasterController: UIViewController, UIDocumentPickerDelegate, UITab
                 }
 
                 if let sectionIndex = self.sections.firstIndex(of: .local) {
-                    let deletionIndexes = deletions.map({ IndexPath(row: $0, section: sectionIndex) })
-                    let insertIndexes = insertions.map({ IndexPath(row: $0, section: sectionIndex) })
-                    self.tableView.deleteRows(at: deletionIndexes, with: .fade)
-                    self.tableView.insertRows(at: insertIndexes, with: .fade)
-                    updates.forEach({ row in
-                        let indexPath = IndexPath(row: row, section: sectionIndex)
-                        guard let cell = self.tableView.cellForRow(at: indexPath) as? TableViewCell else {return}
-                        self.configure(localCell: cell, row: row)
-                    })
+                    if deletions.isEmpty, insertions.isEmpty {
+                        updates.forEach({ row in
+                            let indexPath = IndexPath(row: row, section: sectionIndex)
+                            guard let cell = self.tableView.cellForRow(at: indexPath) as? TableViewCell else {return}
+                            self.configure(localCell: cell, row: row)
+                        })
+                    } else {
+                        self.tableView.reloadSections([sectionIndex], with: .automatic)
+                    }
                 }
             })
         })
-        downloadZimFilesChangeToken = downloadZimFiles?.observe({ (changes) in
+        downloadZimFilesChangeToken = downloadZimFiles?.observe({ [unowned self] changes in
             guard case let .update(results, deletions, insertions, updates) = changes else {return}
             self.downloadZimFilesCount = results.count
             self.tableView.performBatchUpdates({
@@ -204,15 +204,15 @@ class LibraryMasterController: UIViewController, UIDocumentPickerDelegate, UITab
                 }
                 
                 if let sectionIndex = self.sections.firstIndex(of: .download) {
-                    let deletionIndexes = deletions.map({ IndexPath(row: $0, section: sectionIndex) })
-                    let insertIndexes = insertions.map({ IndexPath(row: $0, section: sectionIndex) })
-                    self.tableView.deleteRows(at: deletionIndexes, with: .fade)
-                    self.tableView.insertRows(at: insertIndexes, with: .fade)
-                    updates.forEach({ row in
-                        let indexPath = IndexPath(row: row, section: sectionIndex)
-                        guard let cell = self.tableView.cellForRow(at: indexPath) as? TableViewCell else {return}
-                        self.configure(downloadCell: cell, row: row)
-                    })
+                    if deletions.isEmpty, insertions.isEmpty {
+                        updates.forEach({ row in
+                            let indexPath = IndexPath(row: row, section: sectionIndex)
+                            guard let cell = self.tableView.cellForRow(at: indexPath) as? TableViewCell else {return}
+                            self.configure(downloadCell: cell, row: row)
+                        })
+                    } else {
+                        self.tableView.reloadSections([sectionIndex], with: .automatic)
+                    }
                 }
             })
         })


### PR DESCRIPTION
<img width="616" alt="Screen Shot 2020-12-26 at 9 40 43 AM" src="https://user-images.githubusercontent.com/8294252/103153416-6d3acc80-475e-11eb-9502-b82395623ac8.png">

There has been ac increasing number of crashes like these. No idea of what the root cause is, since none of mine code has changed on these areas for nearly a year. It could very possible that this is on realm or UIKit side. Anyway, I changed the deletion + insertion to just reload section and find the visual result identical or similar. 

This is a more permanent solution for #329