### PR TITLE
Fix/518 - new tab on macos

### DIFF
--- a/Model/Utilities/URL.swift
+++ b/Model/Utilities/URL.swift
@@ -17,5 +17,9 @@ extension URL {
         return scheme?.caseInsensitiveCompare("kiwix") == .orderedSame
     }
     
+    var isExternalLink: Bool {
+        return scheme == "http" || scheme == "https"
+    }
+    
     static let documentDirectory = try! FileManager.default.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: false)
 }

--- a/ViewModel/BrowserViewModel.swift
+++ b/ViewModel/BrowserViewModel.swift
@@ -392,11 +392,6 @@ class BrowserViewModel: NSObject, ObservableObject,
             }
         }
     }
-    
-    // TODO: Utils
-    func isExternalLink(url: URL) -> Bool {
-        return url.scheme == "http" || url.scheme == "https"
-    }
 
     // MARK: - New tab in macos desktop
       

--- a/ViewModel/BrowserViewModel.swift
+++ b/ViewModel/BrowserViewModel.swift
@@ -402,7 +402,7 @@ class BrowserViewModel: NSObject, ObservableObject,
           guard let newUrl = navigationAction.request.url else { return nil }
           
           // open external link in default browser
-          if(newUrl.isExternalLink) {
+          if newUrl.isExternalLink {
               self.openExternalLinkURL = newUrl
               return nil
           }

--- a/ViewModel/BrowserViewModel.swift
+++ b/ViewModel/BrowserViewModel.swift
@@ -407,7 +407,7 @@ class BrowserViewModel: NSObject, ObservableObject,
           guard let newUrl = navigationAction.request.url else { return nil }
           
           // open external link in default browser
-          if(isExternalLink(url: newUrl)) {
+          if(newUrl.isExternalLink) {
               self.openExternalLinkURL = newUrl
               return nil
           }

--- a/ViewModel/BrowserViewModel.swift
+++ b/ViewModel/BrowserViewModel.swift
@@ -396,7 +396,8 @@ class BrowserViewModel: NSObject, ObservableObject,
     // MARK: - New tab in macos desktop
       
       #if os(macOS)
-      func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration, for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {
+      func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration,
+                   for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {
           
           guard navigationAction.targetFrame == nil else { return nil }
           guard let newUrl = navigationAction.request.url else { return nil }

--- a/Views/BrowserTab.swift
+++ b/Views/BrowserTab.swift
@@ -38,7 +38,7 @@ struct BrowserTab: View {
         .focusedSceneValue(\.browserViewModel, browser)
         .focusedSceneValue(\.canGoBack, browser.canGoBack)
         .focusedSceneValue(\.canGoForward, browser.canGoForward)
-        .modifier(ExternalLinkHandler())
+        .modifier(ExternalLinkHandler(externalURL: $browser.openExternalLinkURL))
         .searchable(text: $search.searchText, placement: .toolbar)
         .modify { view in
             #if os(macOS)

--- a/Views/ViewModifiers/ExternalLinkHandler.swift
+++ b/Views/ViewModifiers/ExternalLinkHandler.swift
@@ -27,7 +27,7 @@ struct ExternalLinkHandler: ViewModifier {
     }
     
     func body(content: Content) -> some View {
-        content.onChange(of: externalURL, perform: { value in
+        content.onChange(of: externalURL, perform: { _ in
             guard let url = externalURL else { return }
             externalURL = URL(string: "") // Reset the value to prevent the alert from showing up again
         


### PR DESCRIPTION
I refactor the way the alert is receiving notification, because with `NotificationCenter` (if there were opened tabs) the alert were displayed in each tabs

## TODO: 

- [ ] Squash commit before merge

Fixes #518