### PR TITLE
Fix opening new tabs on macos(#518)

### DIFF
--- a/App/CompactViewController.swift
+++ b/App/CompactViewController.swift
@@ -130,7 +130,7 @@ private struct Content: View {
         .focusedSceneValue(\.browserViewModel, browser)
         .focusedSceneValue(\.canGoBack, browser.canGoBack)
         .focusedSceneValue(\.canGoForward, browser.canGoForward)
-        .modifier(ExternalLinkHandler())
+        .modifier(ExternalLinkHandler(externalURL: browser.externalURL))
         .onAppear {
             browser.updateLastOpened()
         }

--- a/Model/Utilities/URL.swift
+++ b/Model/Utilities/URL.swift
@@ -16,6 +16,10 @@ extension URL {
     var isKiwixURL: Bool {
         return scheme?.caseInsensitiveCompare("kiwix") == .orderedSame
     }
-    
+
+    var isExternal: Bool {
+        ["http", "https"].contains(scheme)
+    }
+
     static let documentDirectory = try! FileManager.default.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: false)
 }

--- a/Views/BrowserTab.swift
+++ b/Views/BrowserTab.swift
@@ -38,7 +38,7 @@ struct BrowserTab: View {
         .focusedSceneValue(\.browserViewModel, browser)
         .focusedSceneValue(\.canGoBack, browser.canGoBack)
         .focusedSceneValue(\.canGoForward, browser.canGoForward)
-        .modifier(ExternalLinkHandler())
+        .modifier(ExternalLinkHandler(externalURL: $browser.externalURL))
         .searchable(text: $search.searchText, placement: .toolbar)
         .modify { view in
             #if os(macOS)

--- a/Views/ViewModifiers/ExternalLinkHandler.swift
+++ b/Views/ViewModifiers/ExternalLinkHandler.swift
@@ -14,8 +14,7 @@ struct ExternalLinkHandler: ViewModifier {
     @State private var isAlertPresented = false
     @State private var activeAlert: ActiveAlert?
     @State private var activeSheet: ActiveSheet?
-    
-    private let externalLink = NotificationCenter.default.publisher(for: .externalLink)
+    @Binding var externalURL: URL?
     
     enum ActiveAlert {
         case ask(url: URL)
@@ -28,8 +27,8 @@ struct ExternalLinkHandler: ViewModifier {
     }
     
     func body(content: Content) -> some View {
-        content.onReceive(externalLink) { notification in
-            guard let url = notification.userInfo?["url"] as? URL else { return }
+        content.onChange(of: externalURL) { url in
+            guard let url else { return }
             switch Defaults[.externalLinkLoadingPolicy] {
             case .alwaysAsk:
                 isAlertPresented = true


### PR DESCRIPTION
Fixing: Open link "in a new window" on macOS.
Partially based on https://github.com/kiwix/apple/pull/526

Known issues:
- the opened tabs are not restoring their content on app restart, the tabID remains nil (might need another issue/ticket).
- command+click on a link would not open it in a new tab (as I would expect it, since native safari has this capability)