### PR TITLE
Fix external link alert macOS

### DIFF
--- a/SwiftUI/Patches.swift
+++ b/SwiftUI/Patches.swift
@@ -62,7 +62,6 @@ extension Color {
 
 extension Notification.Name {
     static let alert = Notification.Name("alert")
-    static let externalLink = Notification.Name("externalLink")
     static let openFiles = Notification.Name("openFiles")
     static let openURL = Notification.Name("openURL")
     static let toggleSidebar = Notification.Name("toggleSidebar")

--- a/ViewModel/BrowserViewModel.swift
+++ b/ViewModel/BrowserViewModel.swift
@@ -45,6 +45,7 @@ class BrowserViewModel: NSObject, ObservableObject,
     @Published private(set) var outlineItems = [OutlineItem]()
     @Published private(set) var outlineItemTree = [OutlineItem]()
     @Published private(set) var url: URL?
+    @Published var externalLink: URL?
     
     let tabID: NSManagedObjectID?
     let webView: WKWebView
@@ -179,7 +180,7 @@ class BrowserViewModel: NSObject, ObservableObject,
         } else if url.isKiwixURL {
             decisionHandler(.allow)
         } else if url.scheme == "http" || url.scheme == "https" {
-            NotificationCenter.default.post(name: .externalLink, object: nil, userInfo: ["url": url])
+            externalLink = url
             decisionHandler(.cancel)
         } else if url.scheme == "geo" {
             if FeatureFlags.map {

--- a/Views/ViewModifiers/ExternalLinkHandler.swift
+++ b/Views/ViewModifiers/ExternalLinkHandler.swift
@@ -11,11 +11,10 @@ import SwiftUI
 import Defaults
 
 struct ExternalLinkHandler: ViewModifier {
+    @EnvironmentObject private var browserViewModel: BrowserViewModel
     @State private var isAlertPresented = false
     @State private var activeAlert: ActiveAlert?
     @State private var activeSheet: ActiveSheet?
-    
-    private let externalLink = NotificationCenter.default.publisher(for: .externalLink)
     
     enum ActiveAlert {
         case ask(url: URL)
@@ -28,8 +27,9 @@ struct ExternalLinkHandler: ViewModifier {
     }
     
     func body(content: Content) -> some View {
-        content.onReceive(externalLink) { notification in
-            guard let url = notification.userInfo?["url"] as? URL else { return }
+        content.onChange(of: browserViewModel.externalLink) { url in
+            defer { browserViewModel.externalLink = nil }
+            guard let url = url else { return }
             switch Defaults[.externalLinkLoadingPolicy] {
             case .alwaysAsk:
                 isAlertPresented = true


### PR DESCRIPTION
There has been an issue on the external URL alert that was left over from my last round of refactoring in the context of multi tabs on iOS / iPadOS. When there are multiple tabs, the alert would show up on all tabs, because it is openURL / notification based.

Instead, I am using a `externalLink` variable in the view model (which is unique to each tab) to store if there is any external link that needs to be handled

<img width="1101" alt="Screenshot 2023-11-19 at 10 21 50 AM" src="https://github.com/kiwix/apple/assets/8294252/90896ac1-7e3b-4ccc-b665-f2b40766e87f">
