### PR TITLE
Enforce localization for custom apps

### DIFF
--- a/App/App_iOS.swift
+++ b/App/App_iOS.swift
@@ -17,8 +17,11 @@ struct Kiwix: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     
     private let fileMonitor: DirectoryMonitor
-    
+
     init() {
+        if let enforcedLanguage: String = Config.value(for: .enforcedLanguage) {
+            DefaultLanguages.enforce(language: enforcedLanguage)
+        }
         fileMonitor = DirectoryMonitor(url: URL.documentDirectory) { LibraryOperations.scanDirectory($0) }
         LibraryOperations.registerBackgroundTask()
         UNUserNotificationCenter.current().delegate = appDelegate

--- a/App/App_macOS.swift
+++ b/App/App_macOS.swift
@@ -19,6 +19,9 @@ struct Kiwix: App {
     private let notificationCenterDelegate = NotificationCenterDelegate()
 
     init() {
+        if let enforcedLanguage: String = Config.value(for: .enforcedLanguage) {
+            DefaultLanguages.enforce(language: enforcedLanguage)
+        }
         UNUserNotificationCenter.current().delegate = notificationCenterDelegate
     }
     

--- a/App/CompactViewController.swift
+++ b/App/CompactViewController.swift
@@ -71,8 +71,13 @@ final class CompactViewController: UIHostingController<AnyView>, UISearchControl
     func willPresentSearchController(_ searchController: UISearchController) {
         navigationController?.setToolbarHidden(true, animated: true)
         navigationItem.setRightBarButton(
-            UIBarButtonItem(title: "common.button.cancel".localized, style: .done, target: self, action: #selector(onSearchCancelled))
-            , animated: true
+            UIBarButtonItem(
+                title: "common.button.cancel".localized,
+                style: .done,
+                target: self,
+                action: #selector(onSearchCancelled)
+            ),
+            animated: true
         )
     }
     @objc func onSearchCancelled() {

--- a/App/CompactViewController.swift
+++ b/App/CompactViewController.swift
@@ -11,7 +11,7 @@ import Combine
 import SwiftUI
 import UIKit
 
-class CompactViewController: UIHostingController<AnyView>, UISearchControllerDelegate, UISearchResultsUpdating {
+final class CompactViewController: UIHostingController<AnyView>, UISearchControllerDelegate, UISearchResultsUpdating {
     private let searchViewModel: SearchViewModel
     private let searchController: UISearchController
     private var searchTextObserver: AnyCancellable?
@@ -50,7 +50,8 @@ class CompactViewController: UIHostingController<AnyView>, UISearchControllerDel
         searchController.delegate = self
         searchController.hidesNavigationBarDuringPresentation = false
         searchController.showsSearchResultsController = true
-        
+        searchController.searchBar.searchTextField.placeholder = "common.search".localized
+
         searchTextObserver = searchViewModel.$searchText.sink { [weak self] searchText in
             guard self?.searchController.searchBar.text != searchText else { return }
             self?.searchController.searchBar.text = searchText
@@ -70,13 +71,15 @@ class CompactViewController: UIHostingController<AnyView>, UISearchControllerDel
     func willPresentSearchController(_ searchController: UISearchController) {
         navigationController?.setToolbarHidden(true, animated: true)
         navigationItem.setRightBarButton(
-            UIBarButtonItem(systemItem: .cancel, primaryAction: UIAction { [unowned self] _ in
-                searchController.isActive = false
-                navigationItem.setRightBarButton(nil, animated: true)
-            }), animated: true
+            UIBarButtonItem(title: "common.button.cancel".localized, style: .done, target: self, action: #selector(onSearchCancelled))
+            , animated: true
         )
     }
-    
+    @objc func onSearchCancelled() {
+        searchController.isActive = false
+        navigationItem.setRightBarButton(nil, animated: true)
+    }
+
     func willDismissSearchController(_ searchController: UISearchController) {
         navigationController?.setToolbarHidden(false, animated: true)
         searchViewModel.searchText = ""

--- a/Kiwix.xcodeproj/project.pbxproj
+++ b/Kiwix.xcodeproj/project.pbxproj
@@ -113,6 +113,7 @@
 		9882080D2B2CF57A00D6B1AE /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 988207FE2B2CF57A00D6B1AE /* Localizable.strings */; };
 		9882080E2B2CF57A00D6B1AE /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 988208012B2CF57A00D6B1AE /* Localizable.strings */; };
 		9882080F2B2CF57A00D6B1AE /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 988208042B2CF57A00D6B1AE /* Localizable.strings */; };
+		98B5D3252B2F36680047CC13 /* DefaultLanguages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98B5D3242B2F36680047CC13 /* DefaultLanguages.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -257,6 +258,7 @@
 		988207FF2B2CF57A00D6B1AE /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = Localizable.strings; sourceTree = "<group>"; };
 		988208022B2CF57A00D6B1AE /* mk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = mk; path = Localizable.strings; sourceTree = "<group>"; };
 		988208052B2CF57A00D6B1AE /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = Localizable.strings; sourceTree = "<group>"; };
+		98B5D3242B2F36680047CC13 /* DefaultLanguages.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultLanguages.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -569,6 +571,7 @@
 		97E94B26271EF359005B0295 /* Support */ = {
 			isa = PBXGroup;
 			children = (
+				98B5D3242B2F36680047CC13 /* DefaultLanguages.swift */,
 				988207FD2B2CF57A00D6B1AE /* de.lproj */,
 				988208032B2CF57A00D6B1AE /* en.lproj */,
 				988207EE2B2CF57A00D6B1AE /* he.lproj */,
@@ -943,6 +946,7 @@
 				974E7EE92930201500BDF59C /* ZimFileService.swift in Sources */,
 				973A0DFD283100C300B41E71 /* ZimFilesOpened.swift in Sources */,
 				9744068A28CF65AE00916BD4 /* LibraryOperations.swift in Sources */,
+				98B5D3252B2F36680047CC13 /* DefaultLanguages.swift in Sources */,
 				972DE4B62814A502004FD9B9 /* Enum.swift in Sources */,
 				9744068728CE263800916BD4 /* DirectoryMonitor.swift in Sources */,
 				974C33A9285589E900DF6F4C /* Patches.swift in Sources */,

--- a/Model/Brand.swift
+++ b/Model/Brand.swift
@@ -66,6 +66,7 @@ enum Config: String {
     case showSearchSnippetInSettings = "SETTINGS_SHOW_SEARCH_SNIPPET"
     case aboutText = "CUSTOM_ABOUT_TEXT"
     case aboutWebsite = "CUSTOM_ABOUT_WEBSITE"
+    case enforcedLanguage = "ENFORCED_LANGUAGE"
 
     static func value<T>(for key: Config) -> T? where T: LosslessStringConvertible {
         guard let object = Bundle.main.object(forInfoDictionaryKey: key.rawValue) else {

--- a/Model/Utilities/String+Extension.swift
+++ b/Model/Utilities/String+Extension.swift
@@ -11,15 +11,33 @@ import Foundation
 extension String {
 
     var localized: String {
-        return NSLocalizedString(self, tableName: nil, bundle: DefaultLanguages.currentBundle, value: "", comment: "")
+        NSLocalizedString(
+            self,
+            tableName: nil,
+            bundle: DefaultLanguages.currentBundle,
+            value: "",
+            comment: ""
+        )
     }
     
     func localized(withComment: String) -> String {
-        return NSLocalizedString(self, tableName: nil, bundle: DefaultLanguages.currentBundle, value: "", comment: withComment)
+        return NSLocalizedString(
+            self,
+            tableName: nil,
+            bundle: DefaultLanguages.currentBundle,
+            value: "",
+            comment: withComment
+        )
     }
     
     func localizedWithFormat(withArgs: CVarArg...) -> String {
-        let format = NSLocalizedString(self, tableName: nil, bundle: DefaultLanguages.currentBundle, value: "", comment: "")
+        let format = NSLocalizedString(
+            self,
+            tableName: nil,
+            bundle: DefaultLanguages.currentBundle,
+            value: "",
+            comment: ""
+        )
 
         switch withArgs.count {
         case 1: return String.localizedStringWithFormat(format, withArgs[0])
@@ -27,5 +45,4 @@ extension String {
         default: return String.localizedStringWithFormat(format, withArgs)
         }
     }
-    
 }

--- a/Model/Utilities/String+Extension.swift
+++ b/Model/Utilities/String+Extension.swift
@@ -9,18 +9,18 @@
 import Foundation
 
 extension String {
-    
+
     var localized: String {
-        return NSLocalizedString(self, tableName: nil, bundle: Bundle.main, value: "", comment: "")
+        return NSLocalizedString(self, tableName: nil, bundle: DefaultLanguages.currentBundle, value: "", comment: "")
     }
     
     func localized(withComment: String) -> String {
-        return NSLocalizedString(self, tableName: nil, bundle: Bundle.main, value: "", comment: withComment)
+        return NSLocalizedString(self, tableName: nil, bundle: DefaultLanguages.currentBundle, value: "", comment: withComment)
     }
     
     func localizedWithFormat(withArgs: CVarArg...) -> String {
-        let format = NSLocalizedString(self, tableName: nil, bundle: Bundle.main, value: "", comment: "")
-        
+        let format = NSLocalizedString(self, tableName: nil, bundle: DefaultLanguages.currentBundle, value: "", comment: "")
+
         switch withArgs.count {
         case 1: return String.localizedStringWithFormat(format, withArgs[0])
         case 2: return String.localizedStringWithFormat(format, withArgs[0], withArgs[1])

--- a/Support/DefaultLanguages.swift
+++ b/Support/DefaultLanguages.swift
@@ -1,0 +1,30 @@
+//
+//  DefaultLanguages.swift
+//  Kiwix
+//
+
+import Foundation
+import Defaults
+
+/// Enforce the selected languages on start up time
+/// It fully works on 2nd launch, as @main cannot be easily overriden in SwiftUI
+/// For the first launch we can override the bundle we use for localization
+enum DefaultLanguages {
+    /// We need a work around bundle with a specific
+    static var currentBundle: Bundle = Bundle.main
+
+    static func enforce(language: String) {
+        if UserDefaults.standard[.isFirstLaunch] {
+            UserDefaults.standard[.isFirstLaunch] = false
+            // override the system picked languages at start
+            UserDefaults.standard.set([language], forKey: "AppleLanguages")
+
+            // override the bundle used on first launch of the app:
+            if let path = Bundle.main.path(forResource: language, ofType: "lproj") {
+                if let langBundle = Bundle.init(path: path) {
+                    currentBundle = langBundle
+                }
+            }
+        }
+    }
+}

--- a/Support/de.lproj/Localizable.strings
+++ b/Support/de.lproj/Localizable.strings
@@ -20,6 +20,7 @@
 "common.button.cancel" = "Abbrechen";
 "common.button.yes" = "Ja";
 "common.button.no" = "nein";
+"common.search" = "Suchen";
 "common.tab.manager.title" = "Tabs-Manager";
 "common.tab.navigation.title" = "Tabs";
 "common.tab.menu.new_tab" = "Neuer Tab";

--- a/Support/en.lproj/Localizable.strings
+++ b/Support/en.lproj/Localizable.strings
@@ -29,6 +29,7 @@
 "common.button.cancel" = "Cancel";
 "common.button.yes" = "Yes";
 "common.button.no" = "no";
+"common.search" = "Search";
 
 "common.tab.manager.title" = "Tabs Manager";
 "common.tab.navigation.title" = "Tabs";

--- a/SwiftUI/Model/DefaultKeys.swift
+++ b/SwiftUI/Model/DefaultKeys.swift
@@ -7,6 +7,7 @@
 //
 
 import Defaults
+import Foundation
 
 extension Defaults.Keys {
 //    // reading
@@ -34,6 +35,7 @@ extension Defaults.Keys {
     static let libraryLastRefresh = Key<Date?>("libraryLastRefresh")
     static let libraryLastRefreshTime = Key<Date?>("libraryLastRefreshTime")
     
+    static let isFirstLaunch = Key<Bool>("isFirstLaunch", default: true)
     static let downloadUsingCellular = Key<Bool>("downloadUsingCellular", default: false)
     static let backupDocumentDirectory = Key<Bool>("backupDocumentDirectory", default: false)
 

--- a/Views/Bookmarks.swift
+++ b/Views/Bookmarks.swift
@@ -37,7 +37,7 @@ struct Bookmarks: View {
         .modifier(GridCommon())
         .modifier(ToolbarRoleBrowser())
         .navigationTitle("bookmark.navigation.title".localized)
-        .searchable(text: $searchText)
+        .searchable(text: $searchText, prompt: "common.search".localized)
         .onChange(of: searchText) { searchText in
             bookmarks.nsPredicate = Bookmarks.buildPredicate(searchText: searchText)
         }

--- a/Views/BrowserTab.swift
+++ b/Views/BrowserTab.swift
@@ -39,7 +39,7 @@ struct BrowserTab: View {
         .focusedSceneValue(\.canGoBack, browser.canGoBack)
         .focusedSceneValue(\.canGoForward, browser.canGoForward)
         .modifier(ExternalLinkHandler(externalURL: $browser.externalURL))
-        .searchable(text: $search.searchText, placement: .toolbar)
+        .searchable(text: $search.searchText, placement: .toolbar, prompt: "common.search".localized)
         .modify { view in
             #if os(macOS)
             view.navigationTitle(browser.articleTitle.isEmpty ? Brand.appName : browser.articleTitle)

--- a/Views/BuildingBlocks/LoadingView.swift
+++ b/Views/BuildingBlocks/LoadingView.swift
@@ -4,7 +4,7 @@ import SwiftUI
 
 struct LoadingView: View {
     var body: some View {
-        Text("Loading...".localized)
+        Text("enum.navigation_item.loading".localized)
     }
 }
 


### PR DESCRIPTION
Fixes #594 

We want to enforce the localization of the apps.
There are a couple of limitations in this:
- Apple is choosing which language should be selected by default on it's own.
- It is possible to override the UserDefaults "AppleLanguages", but swift UI cannot do this early enough (main function is provided by Apple and we don't know how to re-implement it in a safe way to override), 
- The result is that t**he full enforcement of the language only works on the second launch of the app** (not fresh install)
- On fresh install we can override the bundle we use to search for localised strings, which works OK, except the search bars' cancel button, which is currently using the system provided button.

![Simulator Screenshot - iPad mini (6th generation) - 2023-12-17 at 14 53 08](https://github.com/kiwix/apple/assets/6784320/912b0f9a-29de-4ea0-a365-7928d5cd9916)
<img width="392" alt="Screenshot 2023-12-17 at 14 52 40" src="https://github.com/kiwix/apple/assets/6784320/e13321a1-8cae-42c9-98ec-7f74dfe737e2">


Since this is a first launch only issue, and not really visible without using the search functionality, I think we can live with this.
