### PR TITLE
585: Replace 'lego' translations with placeholders and arguments

### DIFF
--- a/Model/DownloadService.swift
+++ b/Model/DownloadService.swift
@@ -194,7 +194,7 @@ class DownloadService: NSObject, URLSessionDelegate, URLSessionTaskDelegate, URL
                 content.title = "download_service.complete.title".localized
                 content.sound = .default
                 if let zimFile = try? context.fetch(ZimFile.fetchRequest(fileID: zimFileID)).first {
-                    content.body = zimFile.name + "download_service.complete.description".localized
+                    content.body = "download_service.complete.description".localizedWithFormat(withArgs: zimFile.name)
                 }
                 
                 // schedule notification

--- a/Support/en.lproj/Localizable.strings
+++ b/Support/en.lproj/Localizable.strings
@@ -14,7 +14,7 @@
 "library_refresh_error.process.description" = "Error processing library data.";
 
 "download_service.complete.title" = "Download Completed";
-"download_service.complete.description" = " has been downloaded successfully.";
+"download_service.complete.description" = "%@ has been downloaded successfully.";
 
 "common.dialog.button.open" = "Open";
 "common.dialog.button.open_in_new_tab" = "Open in New Tab";
@@ -62,7 +62,7 @@
 "external_link_handler.alert.ask.description" = "An external link is tapped, do you wish to load the link?";
 "external_link_handler.alert.not_loading.description" = "An external link is tapped. However, your current setting does not allow it to be loaded.";
 "file_import.alert.no_open.title" = "Unable to open file";
-"file_import.alert.no_open.message" = " cannot be opened.";
+"file_import.alert.no_open.message" = "%@ cannot be opened.";
 
 "article_cell.no_snippet.label" = "No snippet";
 "attribute.detail.unknown" = "Unknown";

--- a/Views/ViewModifiers/FileImport.swift
+++ b/Views/ViewModifiers/FileImport.swift
@@ -104,7 +104,7 @@ struct OpenFileHandler: ViewModifier {
             switch alert {
             case .unableToOpen(let filenames):
                 let name = ListFormatter.localizedString(byJoining: filenames)
-                Text(name + "file_import.alert.no_open.message".localized)
+                Text("file_import.alert.no_open.message".localizedWithFormat(withArgs: name))
             }
         }
     }


### PR DESCRIPTION
Fixing issue #585 by replacing "lego" translations with positional arguments and placeholders.