### PR TITLE
post XcodeGen: Remove libkiwix version from gitactions, update readme

### DIFF
--- a/.github/actions/xcbuild/action.yml
+++ b/.github/actions/xcbuild/action.yml
@@ -10,8 +10,6 @@ inputs:
     required: true
   upload-to:
     required: true
-  libkiwix-version:
-    required: true
   APPLE_DEVELOPMENT_SIGNING_CERTIFICATE:
     required: true
   APPLE_DEVELOPMENT_SIGNING_P12_PASSWORD:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,7 +8,6 @@ on:
     types: [published]
 
 env:
-  LIBKIWIX_VERSION: "13.0.0-1"
   KEYCHAIN: /Users/runner/build.keychain-db
   KEYCHAIN_PASSWORD: mysecretpassword
   KEYCHAIN_PROFILE: build-profile
@@ -125,7 +124,6 @@ jobs:
         action: archive
         xc-destination: generic/platform=${{ matrix.destination.platform }}
         upload-to: ${{ matrix.destination.uploadto }}
-        libkiwix-version: ${{ env.LIBKIWIX_VERSION }}
         version: ${{ env.VERSION }}
         APPLE_DEVELOPMENT_SIGNING_CERTIFICATE: ${{ secrets.APPLE_DEVELOPMENT_SIGNING_CERTIFICATE }}
         APPLE_DEVELOPMENT_SIGNING_P12_PASSWORD: ${{ secrets.APPLE_DEVELOPMENT_SIGNING_P12_PASSWORD }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ on:
       - main
 
 env:
-  LIBKIWIX_VERSION: "13.0.0-1"
   APPLE_STORE_AUTH_KEY_PATH: /tmp/authkey.p8
 
 jobs:
@@ -66,7 +65,6 @@ jobs:
           action: build
           xc-destination: generic/platform=${{ matrix.destination.platform }}
           upload-to: dev
-          libkiwix-version: ${{ env.LIBKIWIX_VERSION }}
           version: CI
           APPLE_DEVELOPMENT_SIGNING_CERTIFICATE: ${{ secrets.APPLE_DEVELOPMENT_SIGNING_CERTIFICATE }}
           APPLE_DEVELOPMENT_SIGNING_P12_PASSWORD: ${{ secrets.APPLE_DEVELOPMENT_SIGNING_P12_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To compile and run Kiwix from Xcode locally, you will need to:
 
 ### Dependencies installed for you
 Our `Brewfile` will install all the necessary dependencies for you: 
-- our latest `CoreKiwix.xcframework` ([libkiwix](https://github.com/kiwix/libkiwix) and [libzim](https://github.com/openzim/libzim))
+- our `CoreKiwix.xcframework` ([libkiwix](https://github.com/kiwix/libkiwix) and [libzim](https://github.com/openzim/libzim)) - the version of which is specified in the `Brewfile`
 - [XcodeGen](https://github.com/yonaskolb/XcodeGen) which will create the project files for you
 
 ### How XcodeGen is working?


### PR DESCRIPTION
Fixing #609 

- Update the CI and CD workflows which were relying on a specific libkiwix version.
- Update the README to reflect that the Brewfile is setting the version of libkiwix to be used.