### PR TITLE
Download dependencies on build step according to parameter

### DIFF
--- a/.github/actions/xcbuild/action.yml
+++ b/.github/actions/xcbuild/action.yml
@@ -114,7 +114,6 @@ runs:
       shell: bash
       run: xcrun xcodebuild -workspace $XC_WORKSPACE -scheme $XC_SCHEME -showBuildSettings
 
-    # build is launched up to twice as it's common the build fails, looking for CoreKiwix module
     - name: Build with Xcode
       env:
         FRAMEWORK_SEARCH_PATHS: ${{ env.PWD }}

--- a/.github/actions/xcbuild/action.yml
+++ b/.github/actions/xcbuild/action.yml
@@ -14,6 +14,9 @@ inputs:
     required: true
   APPLE_DEVELOPMENT_SIGNING_P12_PASSWORD:
     required: true
+  DOWNLOAD_DEPENDENCIES:
+    required: true
+    default: true
   DEPLOYMENT_SIGNING_CERTIFICATE:
     required: false
   DEPLOYMENT_SIGNING_CERTIFICATE_P12_PASSWORD:
@@ -95,7 +98,8 @@ runs:
         KEYCHAIN: ${{ inputs.KEYCHAIN }}
         KEYCHAIN_PASSWORD: ${{ inputs.KEYCHAIN_PASSWORD }}
 
-    - name: Download dependencies
+    - name: Download dependencies if needed
+      if: ${{ inputs.DOWNLOAD_DEPENDENCIES }}
       shell: bash
       run: brew bundle
 

--- a/.github/actions/xcbuild/action.yml
+++ b/.github/actions/xcbuild/action.yml
@@ -15,7 +15,7 @@ inputs:
   APPLE_DEVELOPMENT_SIGNING_P12_PASSWORD:
     required: true
   DOWNLOAD_DEPENDENCIES:
-    required: true
+    required: false
     default: true
   DEPLOYMENT_SIGNING_CERTIFICATE:
     required: false

--- a/.github/actions/xcbuild/action.yml
+++ b/.github/actions/xcbuild/action.yml
@@ -19,7 +19,7 @@ inputs:
     default: true
   ROOT:
     required: true
-    default: .
+    default: "."
   DEPLOYMENT_SIGNING_CERTIFICATE:
     required: false
   DEPLOYMENT_SIGNING_CERTIFICATE_P12_PASSWORD:

--- a/.github/actions/xcbuild/action.yml
+++ b/.github/actions/xcbuild/action.yml
@@ -16,7 +16,7 @@ inputs:
     required: true
   DOWNLOAD_DEPENDENCIES:
     required: false
-    default: true
+    default: 'true'
   DEPLOYMENT_SIGNING_CERTIFICATE:
     required: false
   DEPLOYMENT_SIGNING_CERTIFICATE_P12_PASSWORD:
@@ -99,7 +99,7 @@ runs:
         KEYCHAIN_PASSWORD: ${{ inputs.KEYCHAIN_PASSWORD }}
 
     - name: Download dependencies if needed
-      if: ${{ inputs.DOWNLOAD_DEPENDENCIES }}
+      if: ${{ inputs.DOWNLOAD_DEPENDENCIES == 'true' }}
       shell: bash
       run: brew bundle
 

--- a/.github/actions/xcbuild/action.yml
+++ b/.github/actions/xcbuild/action.yml
@@ -17,9 +17,6 @@ inputs:
   DOWNLOAD_DEPENDENCIES:
     required: true
     default: true
-  ROOT:
-    required: true
-    default: .
   DEPLOYMENT_SIGNING_CERTIFICATE:
     required: false
   DEPLOYMENT_SIGNING_CERTIFICATE_P12_PASSWORD:
@@ -85,7 +82,7 @@ runs:
         security unlock-keychain -p $KEYCHAIN_PASSWORD $KEYCHAIN
 
     - name: Add Apple Development certificate to Keychain
-      uses: ${{ inputs.ROOT }}/.github/actions/install-cert
+      uses: ./.github/actions/install-cert
       with:
         SIGNING_CERTIFICATE: ${{ inputs.APPLE_DEVELOPMENT_SIGNING_CERTIFICATE }}
         SIGNING_CERTIFICATE_P12_PASSWORD: ${{ inputs.APPLE_DEVELOPMENT_SIGNING_P12_PASSWORD }}
@@ -94,7 +91,7 @@ runs:
 
     - name: Add Distribution certificate to Keychain
       if: ${{ inputs.DEPLOYMENT_SIGNING_CERTIFICATE }}
-      uses: ${{ inputs.ROOT }}/.github/actions/install-cert
+      uses: ./.github/actions/install-cert
       with:
         SIGNING_CERTIFICATE: ${{ inputs.DEPLOYMENT_SIGNING_CERTIFICATE }}
         SIGNING_CERTIFICATE_P12_PASSWORD: ${{ inputs.DEPLOYMENT_SIGNING_CERTIFICATE_P12_PASSWORD }}

--- a/.github/actions/xcbuild/action.yml
+++ b/.github/actions/xcbuild/action.yml
@@ -17,6 +17,9 @@ inputs:
   DOWNLOAD_DEPENDENCIES:
     required: true
     default: true
+  ROOT:
+    required: true
+    default: .
   DEPLOYMENT_SIGNING_CERTIFICATE:
     required: false
   DEPLOYMENT_SIGNING_CERTIFICATE_P12_PASSWORD:
@@ -82,7 +85,7 @@ runs:
         security unlock-keychain -p $KEYCHAIN_PASSWORD $KEYCHAIN
 
     - name: Add Apple Development certificate to Keychain
-      uses: ./.github/actions/install-cert
+      uses: ${{ inputs.ROOT }}/.github/actions/install-cert
       with:
         SIGNING_CERTIFICATE: ${{ inputs.APPLE_DEVELOPMENT_SIGNING_CERTIFICATE }}
         SIGNING_CERTIFICATE_P12_PASSWORD: ${{ inputs.APPLE_DEVELOPMENT_SIGNING_P12_PASSWORD }}
@@ -91,7 +94,7 @@ runs:
 
     - name: Add Distribution certificate to Keychain
       if: ${{ inputs.DEPLOYMENT_SIGNING_CERTIFICATE }}
-      uses: ./.github/actions/install-cert
+      uses: ${{ inputs.ROOT }}/.github/actions/install-cert
       with:
         SIGNING_CERTIFICATE: ${{ inputs.DEPLOYMENT_SIGNING_CERTIFICATE }}
         SIGNING_CERTIFICATE_P12_PASSWORD: ${{ inputs.DEPLOYMENT_SIGNING_CERTIFICATE_P12_PASSWORD }}

--- a/.github/actions/xcbuild/action.yml
+++ b/.github/actions/xcbuild/action.yml
@@ -19,7 +19,7 @@ inputs:
     default: true
   ROOT:
     required: true
-    default: "."
+    default: .
   DEPLOYMENT_SIGNING_CERTIFICATE:
     required: false
   DEPLOYMENT_SIGNING_CERTIFICATE_P12_PASSWORD:


### PR DESCRIPTION
Adding an additional flag to the build workflow, if the dependencies should be downloaded as part of this workflow or not.
Will be handy for custom apps, for which we resolve the dependencies earlier.