### PR TITLE
Fix search crashing

### DIFF
--- a/SwiftUI/Model/SearchOperation/SearchOperation.mm
+++ b/SwiftUI/Model/SearchOperation/SearchOperation.mm
@@ -80,23 +80,20 @@
     for (auto result = resultSet.begin(); result != resultSet.end(); result++) {
         if (self.isCancelled) { break; }
         
+        zim::Item item = result->getItem(result->isRedirect());
         NSUUID *zimFileID = [[NSUUID alloc] initWithUUIDBytes:(unsigned char *)result.getZimId().data];
-        NSString *path = [NSString stringWithCString:result.getPath().c_str() encoding:NSUTF8StringEncoding];
-
-        NSString *title = [NSString stringWithCString:result.getTitle().c_str() encoding:NSUTF8StringEncoding];
-        if (title.length > 0) {
-            SearchResult *searchResult = [[SearchResult alloc] initWithZimFileID:zimFileID path:path title:title];
-            if (searchResult == nil) { break; }
-            searchResult.probability = [[NSNumber alloc] initWithFloat:result.getScore() / 100];
-
-            // optionally, add snippet
-            if (self.extractMatchingSnippet) {
-                NSString *html = [NSString stringWithCString:result.getSnippet().c_str() encoding:NSUTF8StringEncoding];
-                searchResult.htmlSnippet = html;
-            }
-
-            [self.results addObject:searchResult];
+        NSString *path = [NSString stringWithCString:item.getPath().c_str() encoding:NSUTF8StringEncoding];
+        NSString *title = [NSString stringWithCString:item.getTitle().c_str() encoding:NSUTF8StringEncoding];
+        SearchResult *searchResult = [[SearchResult alloc] initWithZimFileID:zimFileID path:path title:title];
+        searchResult.probability = [[NSNumber alloc] initWithFloat:result.getScore() / 100];
+        
+        // optionally, add snippet
+        if (self.extractMatchingSnippet) {
+            NSString *html = [NSString stringWithCString:result.getSnippet().c_str() encoding:NSUTF8StringEncoding];
+            searchResult.htmlSnippet = html;
         }
+        
+        if (searchResult != nil) { [self.results addObject:searchResult]; }
     }
 }
 

--- a/SwiftUI/Model/SearchOperation/SearchOperation.mm
+++ b/SwiftUI/Model/SearchOperation/SearchOperation.mm
@@ -108,15 +108,13 @@
         auto results = zim::SuggestionSearcher(archive).suggest(self.searchText_C).getResults(0, count);
         for (auto result = results.begin(); result != results.end(); result++) {
             if (self.isCancelled) { break; }
-            try {
-                zim::Entry entry = result.getEntry();
-                zim::Item item = entry.getItem(entry.isRedirect());
-                NSString *path = [NSString stringWithCString:item.getPath().c_str() encoding:NSUTF8StringEncoding];
-                NSString *title = [NSString stringWithCString:item.getTitle().c_str() encoding:NSUTF8StringEncoding];
+            NSString *path = [NSString stringWithCString:result->getPath().c_str() encoding:NSUTF8StringEncoding];
+            NSString *title = [NSString stringWithCString:result->getTitle().c_str() encoding:NSUTF8StringEncoding];
+            if (title.length > 0) {
                 SearchResult *searchResult = [[SearchResult alloc] initWithZimFileID:zimFileID path:path title:title];
-                if (searchResult != nil) { [self.results addObject:searchResult]; }
-            } catch (std::exception) {
-                NSLog(@"Error in ZIM entry during search.");
+                if (searchResult != nil) {
+                    [self.results addObject:searchResult];
+                }
             }
         }
     }

--- a/SwiftUI/Model/SearchOperation/SearchOperation.mm
+++ b/SwiftUI/Model/SearchOperation/SearchOperation.mm
@@ -108,13 +108,16 @@
         auto results = zim::SuggestionSearcher(archive).suggest(self.searchText_C).getResults(0, count);
         for (auto result = results.begin(); result != results.end(); result++) {
             if (self.isCancelled) { break; }
-            
-            zim::Entry entry = result.getEntry();
-            zim::Item item = entry.getItem(entry.isRedirect());
-            NSString *path = [NSString stringWithCString:item.getPath().c_str() encoding:NSUTF8StringEncoding];
-            NSString *title = [NSString stringWithCString:item.getTitle().c_str() encoding:NSUTF8StringEncoding];
-            SearchResult *searchResult = [[SearchResult alloc] initWithZimFileID:zimFileID path:path title:title];
-            if (searchResult != nil) { [self.results addObject:searchResult]; }
+            try {
+                zim::Entry entry = result.getEntry();
+                zim::Item item = entry.getItem(entry.isRedirect());
+                NSString *path = [NSString stringWithCString:item.getPath().c_str() encoding:NSUTF8StringEncoding];
+                NSString *title = [NSString stringWithCString:item.getTitle().c_str() encoding:NSUTF8StringEncoding];
+                SearchResult *searchResult = [[SearchResult alloc] initWithZimFileID:zimFileID path:path title:title];
+                if (searchResult != nil) { [self.results addObject:searchResult]; }
+            } catch (std::exception) {
+                NSLog(@"Error in ZIM entry during search.");
+            }
         }
     }
 }

--- a/SwiftUI/Model/SearchOperation/SearchOperation.mm
+++ b/SwiftUI/Model/SearchOperation/SearchOperation.mm
@@ -84,6 +84,9 @@
         NSUUID *zimFileID = [[NSUUID alloc] initWithUUIDBytes:(unsigned char *)result.getZimId().data];
         NSString *path = [NSString stringWithCString:item.getPath().c_str() encoding:NSUTF8StringEncoding];
         NSString *title = [NSString stringWithCString:item.getTitle().c_str() encoding:NSUTF8StringEncoding];
+        if (title.length == 0) {
+            title = path; // display the path as a fallback
+        }
         SearchResult *searchResult = [[SearchResult alloc] initWithZimFileID:zimFileID path:path title:title];
         searchResult.probability = [[NSNumber alloc] initWithFloat:result.getScore() / 100];
         

--- a/SwiftUI/Model/SearchOperation/SearchOperation.mm
+++ b/SwiftUI/Model/SearchOperation/SearchOperation.mm
@@ -80,20 +80,23 @@
     for (auto result = resultSet.begin(); result != resultSet.end(); result++) {
         if (self.isCancelled) { break; }
         
-        zim::Item item = result->getItem(result->isRedirect());
         NSUUID *zimFileID = [[NSUUID alloc] initWithUUIDBytes:(unsigned char *)result.getZimId().data];
-        NSString *path = [NSString stringWithCString:item.getPath().c_str() encoding:NSUTF8StringEncoding];
-        NSString *title = [NSString stringWithCString:item.getTitle().c_str() encoding:NSUTF8StringEncoding];
-        SearchResult *searchResult = [[SearchResult alloc] initWithZimFileID:zimFileID path:path title:title];
-        searchResult.probability = [[NSNumber alloc] initWithFloat:result.getScore() / 100];
-        
-        // optionally, add snippet
-        if (self.extractMatchingSnippet) {
-            NSString *html = [NSString stringWithCString:result.getSnippet().c_str() encoding:NSUTF8StringEncoding];
-            searchResult.htmlSnippet = html;
+        NSString *path = [NSString stringWithCString:result.getPath().c_str() encoding:NSUTF8StringEncoding];
+
+        NSString *title = [NSString stringWithCString:result.getTitle().c_str() encoding:NSUTF8StringEncoding];
+        if (title.length > 0) {
+            SearchResult *searchResult = [[SearchResult alloc] initWithZimFileID:zimFileID path:path title:title];
+            if (searchResult == nil) { break; }
+            searchResult.probability = [[NSNumber alloc] initWithFloat:result.getScore() / 100];
+
+            // optionally, add snippet
+            if (self.extractMatchingSnippet) {
+                NSString *html = [NSString stringWithCString:result.getSnippet().c_str() encoding:NSUTF8StringEncoding];
+                searchResult.htmlSnippet = html;
+            }
+
+            [self.results addObject:searchResult];
         }
-        
-        if (searchResult != nil) { [self.results addObject:searchResult]; }
     }
 }
 


### PR DESCRIPTION
Fixes #635
Fixes #631

The wikimed custom app was crashing if the user did any search.

# Solution
Use a similar implementation as on Android, to avoid errors to be thrown when the search result has an empty title.
Filter out any empty titles, as they won't be useful for the end user (it creates blank lines in search results).