### PR TITLE
Enable manual workflow for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   pull_request_target:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
We want to update our CI / CD process, here: https://github.com/kiwix/apple/pull/641

 In order to safely do this, we need to run the changed files on GithubAction.
The CD process can be triggered manually on a specified branch, however the CI process not.
The pull request itself is triggering the main branch's CI process, but that's not what we want to check in this case.
For this reasons, we need to enable the manual trigger for CI as well.
We can remove it, once we finish working on these updates, if needed.