### PR TITLE
Filter categories by content languages

### DIFF
--- a/App/App_macOS.swift
+++ b/App/App_macOS.swift
@@ -97,7 +97,7 @@ struct RootView: View {
                 if FeatureFlags.hasLibrary {
                     Section("app_macos_navigation.button.library".localized) {
                         ForEach(libraryItems, id: \.self) { navigationItem in
-                            Label(navigationItem.name.localized, systemImage: navigationItem.icon)
+                            Label(navigationItem.name, systemImage: navigationItem.icon)
                         }
                     }
                 }

--- a/Model/CategoriesToLanguage.swift
+++ b/Model/CategoriesToLanguage.swift
@@ -23,4 +23,12 @@ struct CategoriesToLanguages {
     static func save(_ dictionary: [Category: Set<String>]) {
         Defaults[.categoriesToLanguages] = dictionary
     }
+
+    static func allCategories() -> [Category] {
+        let categoriesToLanguages = CategoriesToLanguages()
+        let contentLanguages = Defaults[.libraryLanguageCodes]
+        return Category.allCases.filter { (category: Category) in
+            categoriesToLanguages.has(category: category, inLanguages: contentLanguages)
+        }
+    }
 }

--- a/Model/CategoriesToLanguage.swift
+++ b/Model/CategoriesToLanguage.swift
@@ -1,0 +1,26 @@
+//
+//  CategoriesToLanguage.swift
+//  Kiwix
+//
+
+import Foundation
+import Defaults
+
+struct CategoriesToLanguages {
+
+    private let dictionary: [Category: Set<String>] = Defaults[.categoriesToLanguages]
+
+    func has(category: Category, inLanguages langCodes: Set<String>) -> Bool {
+        guard !langCodes.isEmpty else {
+            return true // no languages provided, do not filter
+        }
+        guard let languages = dictionary[category] else {
+            return false
+        }
+        return !languages.intersection(langCodes).isEmpty
+    }
+
+    static func save(_ dictionary: [Category: Set<String>]) {
+        Defaults[.categoriesToLanguages] = dictionary
+    }
+}

--- a/Model/CategoriesToLanguage.swift
+++ b/Model/CategoriesToLanguage.swift
@@ -17,7 +17,7 @@ struct CategoriesToLanguages {
         guard let languages = dictionary[category] else {
             return false
         }
-        return !languages.intersection(langCodes).isEmpty
+        return !languages.isDisjoint(with: langCodes)
     }
 
     static func save(_ dictionary: [Category: Set<String>]) {

--- a/Model/Entities/Entities.swift
+++ b/Model/Entities/Entities.swift
@@ -62,7 +62,8 @@ struct Language: Identifiable, Comparable {
     let count: Int
     
     init?(code: String, count: Int) {
-        guard let name = Locale.current.localizedString(forLanguageCode: code) else { return nil }
+        let langCode = NSLocale.canonicalLocaleIdentifier(from: code)
+        guard let name = Locale.current.localizedString(forLanguageCode: langCode) else { return nil }
         self.code = code
         self.name = name
         self.count = count

--- a/SwiftUI/Model/DefaultKeys.swift
+++ b/SwiftUI/Model/DefaultKeys.swift
@@ -39,6 +39,8 @@ extension Defaults.Keys {
     static let downloadUsingCellular = Key<Bool>("downloadUsingCellular", default: false)
     static let backupDocumentDirectory = Key<Bool>("backupDocumentDirectory", default: false)
 
+    static let categoriesToLanguages = Key<[Category: Set<String>]>("categoriesToLanguages", default: [:])
+
     #if os(macOS)
     // window management:
     static let windowURLs = Key<[URL]>("windowURLs", default: [])

--- a/SwiftUI/Model/Enum.swift
+++ b/SwiftUI/Model/Enum.swift
@@ -51,9 +51,9 @@ enum Category: String, CaseIterable, Identifiable, LosslessStringConvertible {
     }
 
     init?(rawValue: String?) {
-        self.init(rawValue: rawValue ?? "")
+        self.init(rawValue: rawValue ?? "other")
     }
-    
+
     var name: String {
         switch self {
         case .wikipedia:

--- a/SwiftUI/Model/Enum.swift
+++ b/SwiftUI/Model/Enum.swift
@@ -28,7 +28,9 @@ enum ActiveSheet: Hashable, Identifiable {
     case safari(url: URL)
 }
 
-enum Category: String, CaseIterable, Identifiable {
+enum Category: String, CaseIterable, Identifiable, LosslessStringConvertible {
+    var description: String { rawValue }
+
     var id: String { rawValue }
     
     case wikipedia
@@ -43,7 +45,11 @@ enum Category: String, CaseIterable, Identifiable {
     case ted
     case stackExchange = "stack_exchange"
     case other
-    
+
+    init?(_ description: String) {
+        self.init(rawValue: description)
+    }
+
     init?(rawValue: String?) {
         self.init(rawValue: rawValue ?? "")
     }

--- a/ViewModel/LibraryViewModel.swift
+++ b/ViewModel/LibraryViewModel.swift
@@ -74,8 +74,8 @@ public class LibraryViewModel: ObservableObject {
     private func saveCategoryAvailableInLanguages(using parser: OPDSParser) {
         var dictionary: [Category: Set<String>] = [:]
         for zimFileID in parser.zimFileIDs {
-            if let meta = parser.getMetaData(id: zimFileID),
-               let category = Category(rawValue: meta.category) {
+            if let meta = parser.getMetaData(id: zimFileID) {
+                let category = Category(rawValue: meta.category) ?? .other
                 let allLanguagesForCategory: Set<String>
                 let categoryLanguages: Set<String> = Set<String>(meta.languageCodes.components(separatedBy: ","))
                 if let existingLanguages = dictionary[category] {
@@ -89,10 +89,10 @@ public class LibraryViewModel: ObservableObject {
         CategoriesToLanguages.save(dictionary)
     }
 
-    /// Make sure we remove any incompatible non 3 char languages already set
+    /// Make sure we remove the incompatible "en" if it was already set
     static func cleanUpDefaultLanguages() {
         Defaults[.libraryLanguageCodes] = Defaults[.libraryLanguageCodes].filter { langCode in
-            langCode.count == 3
+            langCode != "en"
         }
     }
 

--- a/Views/Library/Library.swift
+++ b/Views/Library/Library.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 import UniformTypeIdentifiers
+import Defaults
 
 #if os(iOS)
 /// Tabbed library view on iOS & iPadOS
@@ -16,7 +17,9 @@ struct Library: View {
     @SceneStorage("LibraryTabItem") private var tabItem: LibraryTabItem = .opened
         
     private let defaultTabItem: LibraryTabItem?
-    
+    private let categoriesToLanguages = CategoriesToLanguages()
+    @Default(.libraryLanguageCodes) private var contentLanguages
+
     init(tabItem: LibraryTabItem? = nil) {
         self.defaultTabItem = tabItem
     }
@@ -29,7 +32,9 @@ struct Library: View {
                     case .opened:
                         ZimFilesOpened()
                     case .categories:
-                        List(Category.allCases) { category in
+                        List(Category.allCases.filter({ (category: Category) in
+                            categoriesToLanguages.has(category: category, inLanguages: contentLanguages)
+                        })) { category in
                             NavigationLink {
                                 ZimFilesCategory(category: .constant(category))
                                     .navigationTitle(category.name)

--- a/Views/Library/Library.swift
+++ b/Views/Library/Library.swift
@@ -17,11 +17,15 @@ struct Library: View {
     @SceneStorage("LibraryTabItem") private var tabItem: LibraryTabItem = .opened
         
     private let defaultTabItem: LibraryTabItem?
-    private let categoriesToLanguages = CategoriesToLanguages()
-    @Default(.libraryLanguageCodes) private var contentLanguages
+    private let categories: [Category]
 
     init(tabItem: LibraryTabItem? = nil) {
         self.defaultTabItem = tabItem
+        let categoriesToLanguages = CategoriesToLanguages()
+        let contentLanguages = Defaults[.libraryLanguageCodes]
+        categories = Category.allCases.filter { (category: Category) in
+            categoriesToLanguages.has(category: category, inLanguages: contentLanguages)
+        }
     }
     
     var body: some View {
@@ -32,9 +36,7 @@ struct Library: View {
                     case .opened:
                         ZimFilesOpened()
                     case .categories:
-                        List(Category.allCases.filter({ (category: Category) in
-                            categoriesToLanguages.has(category: category, inLanguages: contentLanguages)
-                        })) { category in
+                        List(categories) { category in
                             NavigationLink {
                                 ZimFilesCategory(category: .constant(category))
                                     .navigationTitle(category.name)

--- a/Views/Library/Library.swift
+++ b/Views/Library/Library.swift
@@ -21,11 +21,7 @@ struct Library: View {
 
     init(tabItem: LibraryTabItem? = nil) {
         self.defaultTabItem = tabItem
-        let categoriesToLanguages = CategoriesToLanguages()
-        let contentLanguages = Defaults[.libraryLanguageCodes]
-        categories = Category.allCases.filter { (category: Category) in
-            categoriesToLanguages.has(category: category, inLanguages: contentLanguages)
-        }
+        categories = CategoriesToLanguages.allCategories()
     }
     
     var body: some View {

--- a/Views/Library/ZimFilesCategories.swift
+++ b/Views/Library/ZimFilesCategories.swift
@@ -16,11 +16,7 @@ struct ZimFilesCategories: View {
     private var categories: [Category]
 
     init() {
-        let contentLanguageCodes = Defaults[.libraryLanguageCodes]
-        let categoriesToLanguages = CategoriesToLanguages()
-        categories = Category.allCases.filter { (category: Category) in
-            categoriesToLanguages.has(category: category, inLanguages: contentLanguageCodes)
-        }
+        categories = CategoriesToLanguages.allCategories()
         selected = categories.first ?? .wikipedia
     }
 

--- a/Views/Library/ZimFilesCategories.swift
+++ b/Views/Library/ZimFilesCategories.swift
@@ -13,7 +13,9 @@ import Defaults
 /// A grid of zim files under each category.
 struct ZimFilesCategories: View {
     @State private var selected: Category = .wikipedia
-    
+    private let categoriesToLanguages = CategoriesToLanguages()
+    @Default(.libraryLanguageCodes) private var contentLanguages
+
     var body: some View {
         ZimFilesCategory(category: $selected)
             .modifier(ToolbarRoleBrowser())
@@ -32,7 +34,9 @@ struct ZimFilesCategories: View {
                 #endif
                 ToolbarItem {
                     Picker("zim_file_category.title".localized, selection: $selected) {
-                        ForEach(Category.allCases) {
+                        ForEach(Category.allCases.filter({ (category: Category) in
+                            categoriesToLanguages.has(category: category, inLanguages: contentLanguages)
+                        })) {
                             Text($0.name).tag($0)
                         }
                     }

--- a/Views/Library/ZimFilesCategories.swift
+++ b/Views/Library/ZimFilesCategories.swift
@@ -12,9 +12,17 @@ import Defaults
 
 /// A grid of zim files under each category.
 struct ZimFilesCategories: View {
-    @State private var selected: Category = .wikipedia
-    private let categoriesToLanguages = CategoriesToLanguages()
-    @Default(.libraryLanguageCodes) private var contentLanguages
+    @State private var selected: Category
+    private var categories: [Category]
+
+    init() {
+        let contentLanguageCodes = Defaults[.libraryLanguageCodes]
+        let categoriesToLanguages = CategoriesToLanguages()
+        categories = Category.allCases.filter { (category: Category) in
+            categoriesToLanguages.has(category: category, inLanguages: contentLanguageCodes)
+        }
+        selected = categories.first ?? .wikipedia
+    }
 
     var body: some View {
         ZimFilesCategory(category: $selected)
@@ -34,9 +42,7 @@ struct ZimFilesCategories: View {
                 #endif
                 ToolbarItem {
                     Picker("zim_file_category.title".localized, selection: $selected) {
-                        ForEach(Category.allCases.filter({ (category: Category) in
-                            categoriesToLanguages.has(category: category, inLanguages: contentLanguages)
-                        })) {
+                        ForEach(categories) {
                             Text($0.name).tag($0)
                         }
                     }

--- a/Views/Settings/LanguageSelector.swift
+++ b/Views/Settings/LanguageSelector.swift
@@ -102,6 +102,10 @@ struct LanguageSelector: View {
     }
     
     private func hide(_ language: Language) {
+        guard Defaults[.libraryLanguageCodes].count > 1 else {
+            // we should not remove all languages, it will produce empty results
+            return
+        }
         Defaults[.libraryLanguageCodes].remove(language.code)
         withAnimation {
             showing.removeAll { $0.code == language.code }

--- a/Views/Settings/LanguageSelector.swift
+++ b/Views/Settings/LanguageSelector.swift
@@ -25,7 +25,7 @@ struct LanguageSelector: View {
                 } set: { isSelected in
                     if isSelected {
                         selected.insert(language.code)
-                    } else {
+                    } else if selected.count > 1 {
                         selected.remove(language.code)
                     }
                 })

--- a/Views/Settings/LanguageSelector.swift
+++ b/Views/Settings/LanguageSelector.swift
@@ -72,7 +72,7 @@ struct LanguageSelector: View {
         .toolbar {
             Picker(selection: $sortingMode) {
                 ForEach(LibraryLanguageSortingMode.allCases) { sortingMode in
-                    Text(sortingMode.name.localized).tag(sortingMode)
+                    Text(sortingMode.name).tag(sortingMode)
                 }
             } label: {
                 Label("language_selector.toolbar.sorting".localized, systemImage: "arrow.up.arrow.down")

--- a/Views/Settings/Settings.swift
+++ b/Views/Settings/Settings.swift
@@ -31,7 +31,7 @@ struct ReadingSettings: View {
                 SettingSection(name: "reading_settings.external_link.title".localized) {
                     Picker(selection: $externalLinkLoadingPolicy) {
                         ForEach(ExternalLinkLoadingPolicy.allCases) { loadingPolicy in
-                            Text(loadingPolicy.name.localized).tag(loadingPolicy)
+                            Text(loadingPolicy.name).tag(loadingPolicy)
                         }
                     } label: { }
                 }
@@ -40,7 +40,7 @@ struct ReadingSettings: View {
                 SettingSection(name: "reading_settings.search_snippet.title".localized) {
                     Picker(selection: $searchResultSnippetMode) {
                         ForEach(SearchResultSnippetMode.allCases) { snippetMode in
-                            Text(snippetMode.name.localized).tag(snippetMode)
+                            Text(snippetMode.name).tag(snippetMode)
                         }
                     } label: { }
                 }

--- a/Views/Settings/Settings.swift
+++ b/Views/Settings/Settings.swift
@@ -153,14 +153,14 @@ struct Settings: View {
             if FeatureFlags.showExternalLinkOptionInSettings {
                 Picker("reading_settings.external_link.title".localized, selection: $externalLinkLoadingPolicy) {
                     ForEach(ExternalLinkLoadingPolicy.allCases) { loadingPolicy in
-                        Text(loadingPolicy.name.localized).tag(loadingPolicy)
+                        Text(loadingPolicy.name).tag(loadingPolicy)
                     }
                 }
             }
             if FeatureFlags.showSearchSnippetInSettings {
                 Picker("reading_settings.search_snippet.title".localized, selection: $searchResultSnippetMode) {
                     ForEach(SearchResultSnippetMode.allCases) { snippetMode in
-                        Text(snippetMode.name.localized).tag(snippetMode)
+                        Text(snippetMode.name).tag(snippetMode)
                     }
                 }
             }
@@ -235,7 +235,7 @@ struct Settings: View {
 
 private struct SelectedLanaguageLabel: View {
     @Default(.libraryLanguageCodes) private var languageCodes
-    
+
     var body: some View {
         HStack {
             Text("settings.selected_language.title".localized)
@@ -247,6 +247,8 @@ private struct SelectedLanaguageLabel: View {
             } else if languageCodes.count > 1 {
                 Text("\(languageCodes.count)").foregroundColor(.secondary)
             }
+        }.task {
+            LibraryViewModel.cleanUpDefaultLanguages()
         }
     }
 }


### PR DESCRIPTION
Fixes: #656 

Also fixes: the language count in settings, and a translations of drop downs in settings.

With this we filter down the categories to non empty ones, depending on the content language settings. Eg: setting it to German only (we won't have TED, which is currently only available in English):

![Simulator Screenshot - iPhone 15 - 2024-02-18 at 09 21 49](https://github.com/kiwix/apple/assets/6784320/5e6d1595-0c2e-4c36-b05c-9ea2e0e6921f)
