### PR TITLE
663 feed fix for language changes

### DIFF
--- a/Model/CategoriesToLanguage.swift
+++ b/Model/CategoriesToLanguage.swift
@@ -11,8 +11,8 @@ struct CategoriesToLanguages {
     private let dictionary: [Category: Set<String>] = Defaults[.categoriesToLanguages]
 
     func has(category: Category, inLanguages langCodes: Set<String>) -> Bool {
-        guard !langCodes.isEmpty else {
-            return true // no languages provided, do not filter
+        guard !langCodes.isEmpty, !dictionary.isEmpty else {
+            return true // no languages or category filters provided, do not filter
         }
         guard let languages = dictionary[category] else {
             return false

--- a/Model/DownloadService.swift
+++ b/Model/DownloadService.swift
@@ -47,7 +47,7 @@ class DownloadService: NSObject, URLSessionDelegate, URLSessionTaskDelegate, URL
     private func startHeartbeat() {
         DispatchQueue.main.async {
             guard self.heartbeat == nil else { return }
-            self.heartbeat = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in
+            self.heartbeat = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { _ in
                 Database.shared.container.performBackgroundTask { context in
                     context.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
                     for (zimFileID, downloadedBytes) in self.totalBytesWritten {

--- a/Model/DownloadService.swift
+++ b/Model/DownloadService.swift
@@ -47,7 +47,7 @@ class DownloadService: NSObject, URLSessionDelegate, URLSessionTaskDelegate, URL
     private func startHeartbeat() {
         DispatchQueue.main.async {
             guard self.heartbeat == nil else { return }
-            self.heartbeat = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { _ in
+            self.heartbeat = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in
                 Database.shared.container.performBackgroundTask { context in
                     context.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
                     for (zimFileID, downloadedBytes) in self.totalBytesWritten {

--- a/SwiftUI/Model/Database.swift
+++ b/SwiftUI/Model/Database.swift
@@ -20,7 +20,8 @@ final class Database {
         let storeChange: NSNotification.Name = .init(rawValue: "NSPersistentStoreRemoteChangeNotification")
         notificationToken = NotificationCenter.default.addObserver(
             forName: storeChange, object: nil, queue: nil) { _ in
-            try? self.mergeChanges()
+                guard !LibraryViewModel.isUpdating else { return }
+                try? self.mergeChanges()
         }
         token = {
             guard let data = UserDefaults.standard.data(forKey: "PersistentHistoryToken") else { return nil }


### PR DESCRIPTION
Fixes #663 

I have tested and fixed both scenarios:
- Fresh install of this version = new user experience
- Install the AppStore version, fetch the catalog, then install this version, check the catalog before and after fetching within this build

There was also a performance issue that had to be solved, the updates were really slow (we have about 3000 records). 
One solution was to do them in batch, one batch per language. 
Later it turned out that even that is not fast enough, as we have this "database changed" event hooked in (partially for iCloud), and it was doing a lot of extra work for each language update batch. The solution was to skip that part while we do the fetching / updating.
