### PR TITLE
Fix webkit sync, and add shortcut cmd+option+R for random page

### DIFF
--- a/Model/Utilities/InSync.swift
+++ b/Model/Utilities/InSync.swift
@@ -1,0 +1,21 @@
+//
+//  InSync.swift
+//  Kiwix
+
+import Foundation
+
+struct InSync {
+    private let queue: DispatchQueue
+
+    init(label: String) {
+        queue = DispatchQueue(label: label, attributes: [.concurrent])
+    }
+
+    func read<T>(_ work: () -> T) -> T {
+        queue.sync(execute: work)
+    }
+
+    func execute(_ work: @escaping () -> Void) {
+        queue.async(flags: .barrier, execute: work)
+    }
+}

--- a/Model/Utilities/WebKitHandler.swift
+++ b/Model/Utilities/WebKitHandler.swift
@@ -16,74 +16,85 @@ import WebKit
 /// which can result in app or webpage frozen.
 /// To mitigate, opting for the less "broken" behavior of ignoring Range header 
 /// until WebKit behavior is changed.
-class KiwixURLSchemeHandler: NSObject, WKURLSchemeHandler {
-    private var urls = Set<URL>()
-    private var queue = DispatchQueue(label: "org.kiwix.webContent", qos: .userInitiated)
-    
+final class KiwixURLSchemeHandler: NSObject, WKURLSchemeHandler {
+    static let KiwixScheme = "kiwix"
+    private let queue = DispatchQueue.main
+    private let inSync = InSync(label: "org.kiwix.url.scheme.sync")
+    private var startedTasks: [Int: Bool] = [:]
+
+    private func startFor(_ hash: Int) {
+        inSync.execute {
+            self.startedTasks[hash] = true
+        }
+    }
+
+    private func isStartedFor(_ hash: Int) -> Bool {
+        return inSync.read {
+            self.startedTasks[hash] != nil
+        }
+    }
+
+    private func stopFor(_ hash: Int) {
+        inSync.execute {
+            self.startedTasks.removeValue(forKey: hash)
+        }
+    }
+
+    private func stopAll() {
+        inSync.execute {
+            self.startedTasks.removeAll()
+        }
+    }
+
     func webView(_ webView: WKWebView, start urlSchemeTask: WKURLSchemeTask) {
-        DispatchQueue.global(qos: .userInitiated).async {
+        let hash = urlSchemeTask.hash
+        guard isStartedFor(hash) == false else { return }
+        startFor(hash)
+
+        queue.async { [weak self] in
             guard let url = urlSchemeTask.request.url, url.isKiwixURL else {
                 urlSchemeTask.didFailWithError(URLError(.unsupportedURL))
+                self?.stopFor(hash)
                 return
             }
-            objCTryBlock { [weak self] in
-                guard let content = ZimFileService.shared.getURLContent(url: url) else {
-                    self?.sendHTTP404Response(urlSchemeTask, url: url)
-                    return
-                }
-                self?.sendHTTP200Response(urlSchemeTask, url: url, content: content)
+            guard let content = ZimFileService.shared.getURLContent(url: url) else {
+                self?.sendHTTP404Response(urlSchemeTask, url: url)
+                self?.stopFor(hash)
+                return
             }
+            self?.sendHTTP200Response(urlSchemeTask, url: url, content: content)
+            self?.stopFor(hash)
         }
     }
     
-    func webView(_ webView: WKWebView, stop urlSchemeTask: WKURLSchemeTask) { }
-    
+    func webView(_ webView: WKWebView, stop urlSchemeTask: WKURLSchemeTask) {
+        stopFor(urlSchemeTask.hash)
+    }
+
+    func didFailProvisionalNavigation() {
+        stopAll()
+    }
+
     private func sendHTTP200Response(_ urlSchemeTask: WKURLSchemeTask, url: URL, content: URLContent) {
         let headers = ["Content-Type": content.mime, "Content-Length": "\(content.size)"]
         if let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: headers) {
+            guard isStartedFor(urlSchemeTask.hash) else { return }
             urlSchemeTask.didReceive(response)
             urlSchemeTask.didReceive(content.data)
             urlSchemeTask.didFinish()
         } else {
+            guard isStartedFor(urlSchemeTask.hash) else { return }
             urlSchemeTask.didFailWithError(URLError(.badServerResponse, userInfo: ["url": url]))
         }
     }
-    
-    private func sendHTTP206Response(_ urlSchemeTask: WKURLSchemeTask, url: URL, content: URLContent) {
-        let headers = [
-            "Content-Type": content.mime,
-            "Content-Length": "\(content.data.count)",
-            "Content-Range": "bytes \(content.start)-\(content.end)/\(content.size)"
-        ]
-        if let response = HTTPURLResponse(url: url, statusCode: 206, httpVersion: "HTTP/1.1", headerFields: headers) {
-            urlSchemeTask.didReceive(response)
-            urlSchemeTask.didReceive(content.data)
-            urlSchemeTask.didFinish()
-        } else {
-            urlSchemeTask.didFailWithError(URLError(.badServerResponse, userInfo: ["url": url]))
-        }
-    }
-    
-    private func sendHTTP400Response(_ urlSchemeTask: WKURLSchemeTask, url: URL) {
-        os_log(
-            "Resource not found for url: %s.",
-            log: Log.URLSchemeHandler,
-            type: .info,
-            url.absoluteString
-        )
-        if let response = HTTPURLResponse(url: url, statusCode: 400, httpVersion: nil, headerFields: nil) {
-            urlSchemeTask.didReceive(response)
-            urlSchemeTask.didFinish()
-        } else {
-            urlSchemeTask.didFailWithError(URLError(.badServerResponse, userInfo: ["url": url]))
-        }
-    }
-    
+
     private func sendHTTP404Response(_ urlSchemeTask: WKURLSchemeTask, url: URL) {
         if let response = HTTPURLResponse(url: url, statusCode: 404, httpVersion: "HTTP/1.1", headerFields: nil) {
+            guard isStartedFor(urlSchemeTask.hash) else { return }
             urlSchemeTask.didReceive(response)
             urlSchemeTask.didFinish()
         } else {
+            guard isStartedFor(urlSchemeTask.hash) else { return }
             urlSchemeTask.didFailWithError(URLError(.badServerResponse, userInfo: ["url": url]))
         }
     }

--- a/Support/Kiwix-Bridging-Header.h
+++ b/Support/Kiwix-Bridging-Header.h
@@ -15,6 +15,7 @@ NS_INLINE NSException * _Nullable objCTryBlock(void(^_Nonnull tryBlock)(void)) {
         return nil;
     }
     @catch (NSException *exception) {
+        NSLog(@"Exception: %s", exception);
         return exception;
     }
 }

--- a/ViewModel/BrowserViewModel.swift
+++ b/ViewModel/BrowserViewModel.swift
@@ -253,15 +253,20 @@ final class BrowserViewModel: NSObject, ObservableObject,
     }
 
     func webView(
-        _: WKWebView,
+        _ webView: WKWebView,
         didFailProvisionalNavigation _: WKNavigation!,
         withError error: Error
     ) {
         let error = error as NSError
+        webView.stopLoading()
+        (webView.configuration
+            .urlSchemeHandler(forURLScheme: KiwixURLSchemeHandler.KiwixScheme) as? KiwixURLSchemeHandler)?
+            .didFailProvisionalNavigation()
         guard error.code != NSURLErrorCancelled else { return }
         NotificationCenter.default.post(
             name: .alert, object: nil, userInfo: ["rawValue": ActiveAlert.articleFailedToLoad.rawValue]
         )
+
     }
 
     // MARK: - WKScriptMessageHandler

--- a/Views/BuildingBlocks/WebView.swift
+++ b/Views/BuildingBlocks/WebView.swift
@@ -85,7 +85,7 @@ class WebViewController: UIViewController {
         NSLayoutConstraint.activate([
             view.leftAnchor.constraint(equalTo: webView.leftAnchor),
             view.bottomAnchor.constraint(equalTo: webView.bottomAnchor),
-            view.rightAnchor.constraint(equalTo: webView.rightAnchor),
+            view.rightAnchor.constraint(equalTo: webView.rightAnchor)
         ])
         topSafeAreaConstraint = view.safeAreaLayoutGuide.topAnchor.constraint(equalTo: webView.topAnchor)
         topSafeAreaConstraint?.isActive = true
@@ -123,7 +123,7 @@ extension WKWebView {
 class WebViewConfiguration: WKWebViewConfiguration {
     override init() {
         super.init()
-        setURLSchemeHandler(KiwixURLSchemeHandler(), forURLScheme: "kiwix")
+        setURLSchemeHandler(KiwixURLSchemeHandler(), forURLScheme: KiwixURLSchemeHandler.KiwixScheme)
         userContentController = {
             let controller = WKUserContentController()
             if FeatureFlags.wikipediaDarkUserCSS,

--- a/Views/Buttons/ArticleShortcutButtons.swift
+++ b/Views/Buttons/ArticleShortcutButtons.swift
@@ -73,6 +73,8 @@ struct ArticleShortcutButtons: View {
         }
         .disabled(zimFiles.isEmpty)
         .help("article_shortcut.random.button.help".localized)
+        .keyboardShortcut(KeyEquivalent("r"), modifiers: [.command, .option])
+
         #elseif os(iOS)
         Menu {
             ForEach(zimFiles) { zimFile in


### PR DESCRIPTION
Fixes #676 

## The root cause
The requests sent to Webkit are handled in a delegate called `WKURLSchemeHandler`. This is making sure that we intercept the request if it starts with the "kiwix" scheme.
Most of the time this was working, although as we start to navigate (or load a random page) at different rates, things can go wrong.
As of Apple's documentation, once a URL scheme task is finished / or errored out, we should no longer use it.
Also as of Apple all of the functions on this scheme task should be called from the main thread.
There were random cases where, the requests and tasks were overlapping, and we ended up sending data, when the task was already finished.

## Solution
- Add a keyboard shortcut (cmd+option+R) to random page button, this way it can be pressed and hold, which will keep loading random pages at a very fast rate, giving us possibility to "stress test" the application.
Also it was agreed, that such short-cut can be handy for our end-users anyway, so I left it in this PR.
- Make sure that the functions are executed only on main thread 
- Make sure we store the (hash of the) task once it is started and remove it once it is finished.
- This way we can check if the given task is still good enough to continue, and we won't "start" the same task twice.
- Make sure that the hash storage of the tasks in itself is thread safe, and we can quickly read & write values, without any data race
- There was one extra case, where the web view could error out, due to unable to load the request in a different delegate, (see: `didFailProvisionalNavigation`) with these changes we are letting know the url scheme handler to take care of this case as well (and clear the hashes).
- **This solution fixes this issue for good, I was not able to reproduce the crash anymore**.

## Testing
Stress tested with the above keyboard short cut (being pressed, and switching pages very very quickly), also tested by simple navigation around the WikiMed content.

## End user impact
Before this change the app was crashing, if a kiwix url cannot be loaded. The crash rate per URL loaded was disturbingly high before.
After these changes, the very worst case scenario the user might face is a "page cannot be loaded" pop-up, if a link cannot be loaded. It will give the user the option to close the pop up and try again. Chances are very high that the link will load the second time. The pop up appearance is a very, very rare scenario at the moment.

## Developer note
This kind of C++ and Objective Exception cannot be caught with our `objCTryBlock`, it will fall through that, and it will equally fall through any swift level attempt of try/catch as well.
In such cases, the only solution is prevention.
Notes from the `WKURLSchemeTask` source comments:
```
public protocol WKURLSchemeTask : NSObjectProtocol {
...
/** ...
     An exception will be thrown if you try to send a new response object after the task has already been completed.
     An exception will be thrown if your app has been told to stop loading this task via the registered WKURLSchemeHandler object.
     */
    func didReceive(_ response: URLResponse)
    
    /* An exception will be thrown if you try to send the task any data before sending it a response.
     An exception will be thrown if you try to send the task any data after the task has already been completed.
     An exception will be thrown if your app has been told to stop loading this task via the registered WKURLSchemeHandler object.
     */
    func didReceive(_ data: Data)
    
     /* An exception will be thrown if you try to mark a task completed after it has already been marked completed or failed.
     An exception will be thrown if your app has been told to stop loading this task via the registered WKURLSchemeHandler object.
     */
    func didFinish()
    
    
    /* An exception will be thrown if your app has been told to stop loading this task via the registered WKURLSchemeHandler object.
     */
    func didFailWithError(_ error: Error)
}
```


