### PR TITLE
601 bookmarks intial cleanup

### DIFF
--- a/Model/Entities/Entities.swift
+++ b/Model/Entities/Entities.swift
@@ -148,7 +148,7 @@ struct URLContent {
     let size: UInt
 }
 
-class ZimFile: NSManagedObject, Identifiable {
+final class ZimFile: NSManagedObject, Identifiable {
     var id: UUID { fileID }
     
     @NSManaged var articleCount: Int64
@@ -159,6 +159,7 @@ class ZimFile: NSManagedObject, Identifiable {
     @NSManaged var faviconURL: URL?
     @NSManaged var fileDescription: String
     @NSManaged var fileID: UUID
+    ///  System file URL, if not nil, it means it's downloaded
     @NSManaged var fileURLBookmark: Data?
     @NSManaged var flavor: String?
     @NSManaged var hasDetails: Bool
@@ -184,11 +185,16 @@ class ZimFile: NSManagedObject, Identifiable {
         }.joined(separator: ",")
     }
 
+    enum Predicate {
+        static let isDownloaded = NSPredicate(format: "fileURLBookmark != nil")
+        static let notDownloaded = NSPredicate(format: "fileURLBookmark == nil")
+        static let notMissing = NSPredicate(format: "isMissing == false")
+    }
+
     static var openedPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
-        NSPredicate(format: "fileURLBookmark != nil"),
-        NSPredicate(format: "isMissing == false")
+        Predicate.isDownloaded,
+        Predicate.notMissing
     ])
-    static var withFileURLBookmarkPredicate = NSPredicate(format: "fileURLBookmark != nil")
     
     class func fetchRequest(
         predicate: NSPredicate? = nil, sortDescriptors: [NSSortDescriptor] = []

--- a/Model/ZimFileService/ZimFileService.h
+++ b/Model/ZimFileService/ZimFileService.h
@@ -26,8 +26,6 @@
 
 # pragma mark - Metadata
 
-- (nullable ZimFileMetaData *)getMetaData:(nonnull NSUUID *)zimFileID NS_REFINED_FOR_SWIFT;
-- (nullable NSData *)getFavicon:(nonnull NSUUID *)zimFileID NS_REFINED_FOR_SWIFT;
 + (nullable ZimFileMetaData *)getMetaDataWithFileURL:(nonnull NSURL *)url NS_REFINED_FOR_SWIFT;
 
 # pragma mark - URL Handling

--- a/Model/ZimFileService/ZimFileService.swift
+++ b/Model/ZimFileService/ZimFileService.swift
@@ -12,8 +12,8 @@ extension ZimFileService {
     static let shared = ZimFileService.__sharedInstance()
     
     /// IDs of currently opened zim files
-    var fileIDs: [UUID] { get { return __getReaderIdentifiers().compactMap({ $0 as? UUID }) } }
-    
+    private var fileIDs: [UUID] { get { return __getReaderIdentifiers().compactMap({ $0 as? UUID }) } }
+
     // MARK: - Reader Management
     
     /// Open a zim file from system file URL bookmark data
@@ -44,14 +44,6 @@ extension ZimFileService {
     func close(fileID: UUID) { __close(fileID) }
     
     // MARK: - Metadata
-    
-    func getMetaData(id: UUID) -> ZimFileMetaData? {
-        __getMetaData(id)
-    }
-    
-    func getFavicon(id: UUID) -> Data? {
-        __getFavicon(id)
-    }
 
     static func getMetaData(url: URL) -> ZimFileMetaData? {
         __getMetaData(withFileURL: url)

--- a/Model/ZimFileService/ZimFileService.swift
+++ b/Model/ZimFileService/ZimFileService.swift
@@ -16,27 +16,27 @@ extension ZimFileService {
     
     // MARK: - Reader Management
     
-    /// Open a zim file from bookmark data
+    /// Open a zim file from system file URL bookmark data
     /// - Parameter bookmark: url bookmark data of the zim file to open
     /// - Returns: new url bookmark data if the one used to open the zim file is stale
     @discardableResult
-    func open(bookmark: Data) throws -> Data? {
+    func open(fileURLBookmark data: Data) throws -> Data? {
         // resolve url
         var isStale: Bool = false
         #if os(macOS)
         guard let url = try? URL(
-            resolvingBookmarkData: bookmark,
+            resolvingBookmarkData: data,
             options: [.withSecurityScope],
             bookmarkDataIsStale: &isStale
         ) else { throw ZimFileOpenError.missing }
         #else
-        guard let url = try? URL(resolvingBookmarkData: bookmark, bookmarkDataIsStale: &isStale) else {
+        guard let url = try? URL(resolvingBookmarkData: data, bookmarkDataIsStale: &isStale) else {
             throw ZimFileOpenError.missing
         }
         #endif
         
         __open(url)
-        return isStale ? ZimFileService.getBookmarkData(url: url) : nil
+        return isStale ? ZimFileService.getFileURLBookmarkData(for: url) : nil
     }
     
     /// Close a zim file
@@ -57,9 +57,15 @@ extension ZimFileService {
         __getMetaData(withFileURL: url)
     }
     
-    // MARK: - URL Bookmark
-    
-    static func getBookmarkData(url: URL) -> Data? {
+    // MARK: - URL System Bookmark
+
+    /// System URL bookmark for the ZIM file itself
+    /// "bookmark data that can later be resolved into a URL object for a file
+    /// even if the user moves or renames it"
+    /// Not to be confused with the article bookmarks
+    /// - Parameter url: file system URL
+    /// - Returns: data that can later be resolved into a URL object
+    static func getFileURLBookmarkData(for url: URL) -> Data? {
         _ = url.startAccessingSecurityScopedResource()
         defer { url.stopAccessingSecurityScopedResource() }
         #if os(macOS)

--- a/Support/Kiwix-Bridging-Header.h
+++ b/Support/Kiwix-Bridging-Header.h
@@ -15,7 +15,6 @@ NS_INLINE NSException * _Nullable objCTryBlock(void(^_Nonnull tryBlock)(void)) {
         return nil;
     }
     @catch (NSException *exception) {
-        NSLog(@"Exception: %s", exception);
         return exception;
     }
 }

--- a/SwiftUI/Model/LibraryOperations.swift
+++ b/SwiftUI/Model/LibraryOperations.swift
@@ -26,11 +26,11 @@ struct LibraryOperations {
     @discardableResult
     static func open(url: URL, onComplete: (() -> Void)? = nil) -> ZimFileMetaData? {
         guard let metadata = ZimFileService.getMetaData(url: url),
-              let fileURLBookmark = ZimFileService.getBookmarkData(url: url) else { return nil }
+              let fileURLBookmark = ZimFileService.getFileURLBookmarkData(for: url) else { return nil }
         
         // open the file
         do {
-            try ZimFileService.shared.open(bookmark: fileURLBookmark)
+            try ZimFileService.shared.open(fileURLBookmark: fileURLBookmark)
         } catch {
             return nil
         }
@@ -57,7 +57,7 @@ struct LibraryOperations {
     static func reopen(onComplete: (() -> Void)?) {
         var successCount = 0
         let context = Database.shared.container.viewContext
-        let request = ZimFile.fetchRequest(predicate: ZimFile.withFileURLBookmarkPredicate)
+        let request = ZimFile.fetchRequest(predicate: ZimFile.Predicate.isDownloaded)
         
         guard let zimFiles = try? context.fetch(request) else {
             onComplete?()
@@ -66,7 +66,7 @@ struct LibraryOperations {
         zimFiles.forEach { zimFile in
             guard let data = zimFile.fileURLBookmark else { return }
             do {
-                if let data = try ZimFileService.shared.open(bookmark: data) {
+                if let data = try ZimFileService.shared.open(fileURLBookmark: data) {
                     zimFile.fileURLBookmark = data
                 }
                 zimFile.isMissing = false

--- a/Tests/LibraryRefreshViewModelTest.swift
+++ b/Tests/LibraryRefreshViewModelTest.swift
@@ -219,7 +219,7 @@ final class LibraryRefreshViewModelTest: XCTestCase {
         XCTAssertNotEqual(zimFile1.fileID, zimFile2.fileID)
         
         // set fileURLBookmark of zim file 2
-        zimFile2.fileURLBookmark = "some file url bookmark data".data(using: .utf8)
+        zimFile2.fileURLBookmark = "/Users/tester/Downloads/file_url.zim".data(using: .utf8)
         try context.save()
 
         // refresh library for the third time

--- a/ViewModel/LibraryViewModel.swift
+++ b/ViewModel/LibraryViewModel.swift
@@ -195,7 +195,7 @@ public class LibraryViewModel: ObservableObject {
                     // delete old zim entries not included in the feed
                     let fetchRequest: NSFetchRequest<NSFetchRequestResult> = ZimFile.fetchRequest()
                     fetchRequest.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
-                        NSPredicate(format: "fileURLBookmark == nil"),
+                        ZimFile.Predicate.notDownloaded,
                         NSPredicate(format: "NOT fileID IN %@", parser.zimFileIDs)
                     ])
                     let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)

--- a/Views/Library/ZimFilesOpened.swift
+++ b/Views/Library/ZimFilesOpened.swift
@@ -14,7 +14,7 @@ struct ZimFilesOpened: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @FetchRequest(
         sortDescriptors: [NSSortDescriptor(keyPath: \ZimFile.size, ascending: false)],
-        predicate: ZimFile.withFileURLBookmarkPredicate,
+        predicate: ZimFile.Predicate.isDownloaded,
         animation: .easeInOut
     ) private var zimFiles: FetchedResults<ZimFile>
     @State private var isFileImporterPresented = false

--- a/Views/SearchResults.swift
+++ b/Views/SearchResults.swift
@@ -18,7 +18,7 @@ struct SearchResults: View {
     @EnvironmentObject private var viewModel: SearchViewModel
     @FetchRequest(
         sortDescriptors: [NSSortDescriptor(keyPath: \ZimFile.size, ascending: false)],
-        predicate: ZimFile.withFileURLBookmarkPredicate,
+        predicate: ZimFile.Predicate.isDownloaded,
         animation: .easeInOut
     ) private var zimFiles: FetchedResults<ZimFile>
     @State private var isClearSearchConfirmationPresented = false


### PR DESCRIPTION
Initial clean up PR, that removes unused functions, clarifies the misleading naming of file URL Bookmark, which has nothing to do with the Bookmarks really.

No change of functionality, just more clarity in code.