### PR TITLE
Fix language selection initial state UI problems

### DIFF
--- a/SwiftUI/Model/DefaultKeys.swift
+++ b/SwiftUI/Model/DefaultKeys.swift
@@ -34,7 +34,6 @@ extension Defaults.Keys {
     static let libraryAutoRefresh = Key<Bool>("libraryAutoRefresh", default: true)
     static let libraryUsingOldISOLangCodes = Key<Bool>("libraryUsingOldISOLangCodes", default: true)
     static let libraryLastRefresh = Key<Date?>("libraryLastRefresh")
-    static let libraryLastRefreshTime = Key<Date?>("libraryLastRefreshTime")
     
     static let isFirstLaunch = Key<Bool>("isFirstLaunch", default: true)
     static let downloadUsingCellular = Key<Bool>("downloadUsingCellular", default: false)

--- a/Views/Library/ZimFilesNew.swift
+++ b/Views/Library/ZimFilesNew.swift
@@ -69,7 +69,7 @@ struct ZimFilesNew: View {
             }
             #endif
             ToolbarItem {
-                if viewModel.isInProgress {
+                if viewModel.state == .inProgress {
                     ProgressView()
                     #if os(macOS)
                         .scaleEffect(0.5)

--- a/Views/Settings/Settings.swift
+++ b/Views/Settings/Settings.swift
@@ -57,12 +57,12 @@ struct LibrarySettings: View {
     
     var body: some View {
         VStack(spacing: 16) {
-            SettingSection(name: "library_settings.catalog.title".localized) {
+            SettingSection(name: "library_settings.catalog.title".localized, alignment: .top) {
                 HStack(spacing: 6) {
                     Button("library_settings.button.refresh_now".localized) {
                         library.start(isUserInitiated: true)
-                    }.disabled(library.isInProgress)
-                    if library.isInProgress {
+                    }.disabled(library.state == .inProgress)
+                    if library.state == .inProgress {
                         ProgressView().progressViewStyle(.circular).scaleEffect(0.5).frame(height: 1)
                     }
                     Spacer()
@@ -173,7 +173,7 @@ struct Settings: View {
                 LanguageSelector()
             } label: {
                 SelectedLanaguageLabel()
-            }
+            }.disabled(library.state != .complete)
             Toggle("library_settings.toggle.cellular".localized, isOn: $downloadUsingCellular)
         } header: {
             Text("library_settings.tab.library.title".localized)
@@ -189,7 +189,7 @@ struct Settings: View {
                 Spacer()
                 LibraryLastRefreshTime().foregroundColor(.secondary)
             }
-            if library.isInProgress {
+            if library.state == .inProgress {
                 HStack {
                     Text("catalog_settings.refreshing.text".localized).foregroundColor(.secondary)
                     Spacer()

--- a/Views/Welcome.swift
+++ b/Views/Welcome.swift
@@ -44,8 +44,8 @@ struct Welcome: View {
             }
             .padding()
             .ignoresSafeArea()
-            .onChange(of: library.isInProgress) { isInProgress in
-                guard !isInProgress else { return }
+            .onChange(of: library.state) { state in
+                guard state != .inProgress else { return }
                 #if os(macOS)
                 navigation.currentItem = .categories
                 #elseif os(iOS)
@@ -70,7 +70,8 @@ struct Welcome: View {
                 GridSection(title: "welcome.main_page.title".localized) {
                     ForEach(zimFiles) { zimFile in
                         Button {
-                            guard let url = ZimFileService.shared.getMainPageURL(zimFileID: zimFile.fileID) else { return }
+                            guard let url = ZimFileService.shared
+                                .getMainPageURL(zimFileID: zimFile.fileID) else { return }
                             browser.load(url: url)
                         } label: {
                             ZimFileCell(zimFile, prominent: .name)
@@ -121,7 +122,7 @@ struct Welcome: View {
             } label: {
                 HStack {
                     Spacer()
-                    if library.isInProgress {
+                    if library.state == .inProgress {
                         #if os(macOS)
                         Text("welcome.button.status.fetching.text".localized)
                         #elseif os(iOS)
@@ -135,7 +136,7 @@ struct Welcome: View {
                     }
                     Spacer()
                 }.padding(6)
-            }.disabled(library.isInProgress)
+            }.disabled(library.state == .inProgress)
         }
         .font(.subheadline)
         .buttonStyle(.bordered)


### PR DESCRIPTION
Fixes #680

The initial state of the applications is that we do not have a list of languages.
We need to indicate it to the user in a reasonable way.
On macOS we also need to update the list of languages if the initial refresh starts from the settings (the same tab, where the list of languages are displayed).
On iPhones the list of languages is under a different section in the settings menu, but that navigation link should also be disabled, when there are no languages to select from.

Also while we are refreshing the language selection should be disabled for the user.

After the changes:
![Screenshot 2024-03-05 at 13 51 37 Medium](https://github.com/kiwix/apple/assets/6784320/08387630-518d-47ec-8726-a6ea91d88a34)
![Screenshot 2024-03-05 at 13 51 42 Medium](https://github.com/kiwix/apple/assets/6784320/55d0cfdb-88e3-44ba-b4da-98ad1ea7f62c)
![Screenshot 2024-03-05 at 13 51 50 Medium](https://github.com/kiwix/apple/assets/6784320/bb5ad181-a2bf-4fd9-8b78-aea47cb35ad2)


Similarly on iOS:
![Simulator Screenshot - iPad mini (6th generation) - 2024-03-05 at 13 48 21 Medium](https://github.com/kiwix/apple/assets/6784320/35080f3b-477e-4e71-8fcd-b8741d171a11)
![Simulator Screenshot - iPad mini (6th generation) - 2024-03-05 at 13 48 31 Medium](https://github.com/kiwix/apple/assets/6784320/ca3291a5-877a-4179-9edf-b9f585736fbe)
