### PR TITLE
634 ZIM download progress fix

### DIFF
--- a/Model/DownloadService.swift
+++ b/Model/DownloadService.swift
@@ -36,8 +36,7 @@ final class DownloadService: NSObject, URLSessionDelegate, URLSessionTaskDelegat
     
     private let queue = DispatchQueue(label: "downloads")
     private let progress = DownloadProgress()
-    private var heartbeat: Timer?
-    
+    @MainActor private var heartbeat: Timer?
     var backgroundCompletionHandler: (() -> Void)?
     private lazy var session: URLSession = {
         let configuration = URLSessionConfiguration.background(withIdentifier: "org.kiwix.background")
@@ -64,7 +63,7 @@ final class DownloadService: NSObject, URLSessionDelegate, URLSessionTaskDelegat
         }
     }
     
-    /// Start heartbeat, which will update database every 0.25 seconds
+    /// Start heartbeat, which will update database every 0.25 second
     private func startHeartbeat() {
         DispatchQueue.main.async {
             guard self.heartbeat == nil else { return }

--- a/Model/DownloadService.swift
+++ b/Model/DownloadService.swift
@@ -1,20 +1,41 @@
 //
 //  DownloadService.swift
 //  Kiwix
-//
-//  Created by Chris Li on 4/30/22.
-//  Copyright © 2022 Chris Li. All rights reserved.
-//
 
 import CoreData
 import UserNotifications
 import os
 
-class DownloadService: NSObject, URLSessionDelegate, URLSessionTaskDelegate, URLSessionDownloadDelegate {
+private final class DownloadProgress {
+    private var dictionary = [UUID: Int64]()
+    private let inSync = InSync(label: "org.kiwix.downloadProgress")
+
+    func updateFor(uuid: UUID, totalBytes: Int64) {
+        inSync.execute { [weak self] in
+            self?.dictionary[uuid] = totalBytes
+        }
+    }
+
+    func values() -> [UUID: Int64] {
+        inSync.read { dictionary }
+    }
+
+    func resetFor(uuid: UUID) {
+        inSync.execute { [weak self] in
+            self?.dictionary.removeValue(forKey: uuid)
+        }
+    }
+
+    func isEmpty() -> Bool {
+        inSync.read { dictionary.isEmpty }
+    }
+}
+
+final class DownloadService: NSObject, URLSessionDelegate, URLSessionTaskDelegate, URLSessionDownloadDelegate {
     static let shared = DownloadService()
     
     private let queue = DispatchQueue(label: "downloads")
-    private var totalBytesWritten = [UUID: Int64]()
+    private let progress = DownloadProgress()
     private var heartbeat: Timer?
     
     var backgroundCompletionHandler: (() -> Void)?
@@ -36,27 +57,29 @@ class DownloadService: NSObject, URLSessionDelegate, URLSessionTaskDelegate, URL
             guard downloadTasks.count > 0 else { return }
             for task in downloadTasks {
                 guard let taskDescription = task.taskDescription,
-                      let zimFileID = UUID(uuidString: taskDescription) else {return}
-                self.totalBytesWritten[zimFileID] = task.countOfBytesReceived
+                      let zimFileID = UUID(uuidString: taskDescription) else { return }
+                self.progress.updateFor(uuid: zimFileID, totalBytes: task.countOfBytesReceived)
             }
             self.startHeartbeat()
         }
     }
     
-    /// Start heartbeat, which will update database every second
+    /// Start heartbeat, which will update database every 0.25 seconds
     private func startHeartbeat() {
         DispatchQueue.main.async {
             guard self.heartbeat == nil else { return }
-            self.heartbeat = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in
-                Database.shared.container.performBackgroundTask { context in
+            self.heartbeat = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: true) { [weak self] _ in
+                Database.shared.container.performBackgroundTask { [weak self] context in
                     context.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
-                    for (zimFileID, downloadedBytes) in self.totalBytesWritten {
-                        let predicate = NSPredicate(format: "fileID == %@", zimFileID as CVarArg)
-                        let request = DownloadTask.fetchRequest(predicate: predicate)
-                        guard let downloadTask = try? context.fetch(request).first else { return }
-                        downloadTask.downloadedBytes = downloadedBytes
+                    if let progressValues = self?.progress.values() {
+                        for (zimFileID, downloadedBytes) in progressValues {
+                            let predicate = NSPredicate(format: "fileID == %@", zimFileID as CVarArg)
+                            let request = DownloadTask.fetchRequest(predicate: predicate)
+                            guard let downloadTask = try? context.fetch(request).first else { return }
+                            downloadTask.downloadedBytes = downloadedBytes
+                        }
+                        try? context.save()
                     }
-                    try? context.save()
                 }
             }
             os_log("Heartbeat started.", log: Log.DownloadService, type: .info)
@@ -209,8 +232,8 @@ class DownloadService: NSObject, URLSessionDelegate, URLSessionTaskDelegate, URL
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
         guard let taskDescription = task.taskDescription,
               let zimFileID = UUID(uuidString: taskDescription) else { return }
-        totalBytesWritten[zimFileID] = nil
-        if totalBytesWritten.count == 0 {
+        progress.resetFor(uuid: zimFileID)
+        if progress.isEmpty() {
             stopHeartbeat()
         }
         
@@ -259,7 +282,7 @@ class DownloadService: NSObject, URLSessionDelegate, URLSessionTaskDelegate, URL
                     totalBytesExpectedToWrite: Int64) {
         guard let taskDescription = downloadTask.taskDescription,
               let zimFileID = UUID(uuidString: taskDescription) else { return }
-        self.totalBytesWritten[zimFileID] = totalBytesWritten
+        progress.updateFor(uuid: zimFileID, totalBytes: totalBytesWritten)
     }
     
     func urlSession(_ session: URLSession,


### PR DESCRIPTION
Fixes #634 

Tested on the attached "broken" Library/container.
The very specifics how downloads and progress are working:
- download starts via http, and we get progress updates, eg: 500 bytes loaded out of 2MB
- these progresses are marked in the SQLite Database under "DownloadTasks"
- the DB is updated from the background context, this allows CoreData syncing to the "view context", and swift ui views are automagically updated
- for this syncing to happen it looks up the list of transactions from a specific time stamp, called token, which is stored in UserDefaults

## What went wrong:
The token is invalid in the "broken" container, meaning there are no transactions to be found after this date.
This can happen for various reasons, either some transactions were corrupted, or old transactions were deleted (as there's a cleanup of transactions at some point as well).
Since the token was invalid, the synchronisation phase could not happen, and there was no recovery.
**The fix for that is to reset the token**. From then on the next synchronisation attempt will carry out successfully, and a new valid token value will be set.

The other issue, I have found that it was crashing from time to time, and that is because the dictionary holding the progress value was read from / writen to different threads, in short in a non thread safe manner. 
Fix: I've added a thread safe wrapper to this dictionary.