### PR TITLE
Fix default language when there's downloaded content already

### DIFF
--- a/Views/Settings/LanguageSelector.swift
+++ b/Views/Settings/LanguageSelector.swift
@@ -150,6 +150,9 @@ class Languages {
         count.expressionResultType = .integer16AttributeType
         
         let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: "ZimFile")
+        // exclude the already downloaded files, they might have invalid language set
+        // but we are mainly interested in fetched content
+        fetchRequest.predicate = ZimFile.Predicate.notDownloaded
         fetchRequest.propertiesToFetch = ["languageCode", count]
         fetchRequest.propertiesToGroupBy = ["languageCode"]
         fetchRequest.resultType = .dictionaryResultType


### PR DESCRIPTION
It is fixing a very edge case of invalid default language selection, I could reproduce from the container uploaded by @kelson42 .
So far I cannot re-create the same crash, but lets try with this fix first merged.

So the issue here is that if there are earlier downloaded files, with 2 letter language codes, they will "count" as valid language codes (since downloaded entries are not cleaned-up in our language migration).
This makes sure we only take "valid" language codes from ZIM files that are not yet downloaded, since we will filter not yet downloaded entries anyway with those language codes.

