### PR TITLE
532 remove long press and re-arrange buttons

### DIFF
--- a/Views/Buttons/TabsManagerButton.swift
+++ b/Views/Buttons/TabsManagerButton.swift
@@ -43,27 +43,27 @@ struct TabsManagerButton: View {
                     Label("common.tab.menu.close_all".localized, systemImage: "xmark.square.fill")
                 }
             }
-            Section {
-                ForEach(zimFiles.prefix(5)) { zimFile in
-                    Button {
-                        browser.loadMainArticle(zimFileID: zimFile.fileID)
-                    } label: { Label(zimFile.name, systemImage: "house") }
-                }
-            }
-            Section {
-                if FeatureFlags.hasLibrary {
-                    Button {
-                        presentedSheet = .library
-                    } label: {
-                        Label("common.tab.menu.library".localized, systemImage: "folder")
-                    }
-                }
-                Button {
-                    presentedSheet = .settings
-                } label: {
-                    Label("common.tab.menu.settings".localized, systemImage: "gear")
-                }
-            }
+//            Section {
+//                ForEach(zimFiles.prefix(5)) { zimFile in
+//                    Button {
+//                        browser.loadMainArticle(zimFileID: zimFile.fileID)
+//                    } label: { Label(zimFile.name, systemImage: "house") }
+//                }
+//            }
+//            Section {
+//                if FeatureFlags.hasLibrary {
+//                    Button {
+//                        presentedSheet = .library
+//                    } label: {
+//                        Label("common.tab.menu.library".localized, systemImage: "folder")
+//                    }
+//                }
+//                Button {
+//                    presentedSheet = .settings
+//                } label: {
+//                    Label("common.tab.menu.settings".localized, systemImage: "gear")
+//                }
+//            }
         } label: {
             Label("common.tab.manager.title".localized, systemImage: "square.stack")
         } primaryAction: {

--- a/Views/Buttons/TabsManagerButton.swift
+++ b/Views/Buttons/TabsManagerButton.swift
@@ -18,9 +18,9 @@ struct TabsManagerButton: View {
     ) private var zimFiles: FetchedResults<ZimFile>
     @State private var presentedSheet: PresentedSheet?
     
-    enum PresentedSheet: String, Identifiable {
+    private enum PresentedSheet: String, Identifiable {
         var id: String { rawValue }
-        case tabsManager, library, settings
+        case tabsManager
     }
     
     var body: some View {
@@ -43,27 +43,6 @@ struct TabsManagerButton: View {
                     Label("common.tab.menu.close_all".localized, systemImage: "xmark.square.fill")
                 }
             }
-//            Section {
-//                ForEach(zimFiles.prefix(5)) { zimFile in
-//                    Button {
-//                        browser.loadMainArticle(zimFileID: zimFile.fileID)
-//                    } label: { Label(zimFile.name, systemImage: "house") }
-//                }
-//            }
-//            Section {
-//                if FeatureFlags.hasLibrary {
-//                    Button {
-//                        presentedSheet = .library
-//                    } label: {
-//                        Label("common.tab.menu.library".localized, systemImage: "folder")
-//                    }
-//                }
-//                Button {
-//                    presentedSheet = .settings
-//                } label: {
-//                    Label("common.tab.menu.settings".localized, systemImage: "gear")
-//                }
-//            }
         } label: {
             Label("common.tab.manager.title".localized, systemImage: "square.stack")
         } primaryAction: {
@@ -83,20 +62,6 @@ struct TabsManagerButton: View {
                         }
                     }
                 }.modifier(MarkAsHalfSheet())
-            case .library:
-                Library()
-            case .settings:
-                NavigationView {
-                    Settings().toolbar {
-                        ToolbarItem(placement: .navigationBarLeading) {
-                            Button {
-                                self.presentedSheet = nil
-                            } label: {
-                                Text("common.button.done".localized).fontWeight(.semibold)
-                            }
-                        }
-                    }
-                }
             }
         }
     }


### PR DESCRIPTION
Fixes #532 
Fixes #474 

Re-arranged the buttons, so no long press is needed to access them:

![Simulator Screenshot - iPhone 6s iOS 15 0 - 2024-03-17 at 00 23 07](https://github.com/kiwix/apple/assets/6784320/daffe0f2-055d-4651-b307-8b5494fe5497)
