### PR TITLE
532 bookmark no long press

### DIFF
--- a/Views/Buttons/BookmarkButton.swift
+++ b/Views/Buttons/BookmarkButton.swift
@@ -80,8 +80,11 @@ struct BookmarkButton: View {
                             }
                         } label: {
                             Label {
-                                Text(browser.articleBookmarked ?
-                                     "common.dialog.button.remove_bookmark".localized : "common.dialog.button.add_bookmark".localized)
+                                Text(
+                                    browser.articleBookmarked ?
+                                    "common.dialog.button.remove_bookmark".localized :
+                                        "common.dialog.button.add_bookmark".localized
+                                )
                             } icon: {
                                 Image(systemName: browser.articleBookmarked ? "star.fill" : "star")
                                     .renderingMode(browser.articleBookmarked ? .original : .template)

--- a/Views/Buttons/BookmarkButton.swift
+++ b/Views/Buttons/BookmarkButton.swift
@@ -71,6 +71,23 @@ struct BookmarkButton: View {
                             Text("common.button.done".localized).fontWeight(.semibold)
                         }
                     }
+                    ToolbarItem(placement: .navigationBarTrailing) {
+                        Button {
+                            if browser.articleBookmarked {
+                                browser.deleteBookmark()
+                            } else {
+                                browser.createBookmark()
+                            }
+                        } label: {
+                            Label {
+                                Text(browser.articleBookmarked ?
+                                     "common.dialog.button.remove_bookmark".localized : "common.dialog.button.add_bookmark".localized)
+                            } icon: {
+                                Image(systemName: browser.articleBookmarked ? "star.fill" : "star")
+                                    .renderingMode(browser.articleBookmarked ? .original : .template)
+                            }
+                        }.disabled(browser.url == nil)
+                    }
                 }
             }
             .frame(idealWidth: 360, idealHeight: 600)


### PR DESCRIPTION
Fixes #532 additional feature change:

Adding the option to add and remove bookmarks without long-press gesture as well, by adding the bookmark icon to the opened sheet top right menu item.
It can have 3 states: 
- disabled if no url is loaded
- enabled, but off - when the url is not bookmarked
- enabled and on - when the url is bookmarked already

![Simulator Screenshot - iPhone 6s iOS 15 0 - 2024-03-17 at 01 02 55 Medium](https://github.com/kiwix/apple/assets/6784320/4b7dbb86-6244-410e-ab6a-db056367f6fe)
![Simulator Screenshot - iPhone 6s iOS 15 0 - 2024-03-17 at 01 02 58 Medium](https://github.com/kiwix/apple/assets/6784320/75e67a34-f34c-409a-b988-024afaa7634a)
![Simulator Screenshot - iPhone 6s iOS 15 0 - 2024-03-17 at 01 02 42 Medium](https://github.com/kiwix/apple/assets/6784320/ec9353f0-9725-4b75-8fc4-21864c2a908d)
