### PR TITLE
Fix same link opened alerts

### DIFF
--- a/Views/ViewModifiers/ExternalLinkHandler.swift
+++ b/Views/ViewModifiers/ExternalLinkHandler.swift
@@ -46,8 +46,11 @@ struct ExternalLinkHandler: ViewModifier {
             if case .ask(let url) = alert {
                 Button("external_link_handler.alert.button.load.link".localized) {
                     load(url: url)
+                    externalURL = nil // important to nil out, so the same link tapped will trigger onChange again
                 }
-                Button("common.button.cancel".localized, role: .cancel) { }
+                Button("common.button.cancel".localized, role: .cancel) {
+                    externalURL = nil // important to nil out, so the same link tapped will trigger onChange again
+                }
             }
         } message: { alert in
             switch alert {


### PR DESCRIPTION
Fixes #701 

The issue is that since we were only listening to externalURL **changes**, when the same link is clicked again,
it did not "changed".

The simplest solution is to `nil' out the `externalURL`, once the alert is closed, either by cancel or by accepting to open the URL.
