### PR TITLE
Add UTF-8 encoding to HTTP headers for text/plain

### DIFF
--- a/Model/Entities/Entities.swift
+++ b/Model/Entities/Entities.swift
@@ -146,6 +146,14 @@ struct URLContent {
     let start: UInt
     let end: UInt
     let size: UInt
+
+    var httpContentType: String {
+        if mime == "text/plain" {
+            return "text/plain;charset=UTf-8"
+        } else {
+            return mime
+        }
+    }
 }
 
 final class ZimFile: NSManagedObject, Identifiable {

--- a/Model/Utilities/WebKitHandler.swift
+++ b/Model/Utilities/WebKitHandler.swift
@@ -76,7 +76,7 @@ final class KiwixURLSchemeHandler: NSObject, WKURLSchemeHandler {
     }
 
     private func sendHTTP200Response(_ urlSchemeTask: WKURLSchemeTask, url: URL, content: URLContent) {
-        let headers = ["Content-Type": content.mime, "Content-Length": "\(content.size)"]
+        let headers = ["Content-Type": content.httpContentType, "Content-Length": "\(content.size)"]
         if let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: headers) {
             guard isStartedFor(urlSchemeTask.hash) else { return }
             urlSchemeTask.didReceive(response)


### PR DESCRIPTION
Fixes #698 

It is displayed as expected:
![Simulator Screenshot - iPhone 15 - 2024-03-22 at 00 05 17 Medium](https://github.com/kiwix/apple/assets/6784320/819c2545-1d04-4f22-a826-98306801e590)
