### PR TITLE
Add extra padding for zoomed in web pages

### DIFF
--- a/Model/Utilities/Javascript.swift
+++ b/Model/Utilities/Javascript.swift
@@ -1,0 +1,29 @@
+// This file is part of Kiwix for iOS & macOS.
+//
+// Kiwix is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// any later version.
+//
+// Kiwix is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kiwix; If not, see https://www.gnu.org/licenses/.
+
+import Foundation
+
+enum CSSUnit: String {
+    case em
+}
+
+enum Javascript {
+    static func webkitPadding(size: UInt8, unit: CSSUnit = .em) -> String {
+        let paddingTemplate = "document.getElementsByTagName('body')[0].style.webkit%@='%d%@'"
+        return ["PaddingStart", "PaddingEnd", "PaddingBefore", "PaddingAfter"].map { property in
+            String(format: paddingTemplate, property, size, unit.rawValue)
+        }.joined(separator: "; ")
+    }
+}

--- a/Model/Utilities/Javascript.swift
+++ b/Model/Utilities/Javascript.swift
@@ -16,6 +16,7 @@
 import Foundation
 
 enum CSSUnit: String {
+    // swiftlint:disable:next identifier_name
     case em
 }
 

--- a/Views/BuildingBlocks/WebView.swift
+++ b/Views/BuildingBlocks/WebView.swift
@@ -74,11 +74,14 @@ final class WebViewController: UIViewController {
     private var layoutCancellable: AnyCancellable?
     private var currentScrollViewOffset: CGFloat = 0.0
     private var compactViewNavigationController: UINavigationController?
-    
+    private static let webkitPaddingJS: String = Javascript.webkitPadding(size: 1, unit: .em)
+
     init(webView: WKWebView) {
         self.webView = webView
         pageZoomObserver = Defaults.observe(.webViewPageZoom) { change in
             webView.adjustTextSize(pageZoom: change.newValue)
+            // adjust padding, as with large zoom in the content is too close to the sides
+            webView.evaluateJavaScript(Self.webkitPaddingJS, completionHandler: nil)
         }
         super.init(nibName: nil, bundle: nil)
     }


### PR DESCRIPTION
Fixes: #885 

## Origin

I have found the zoom functionality is applying a JS callback to adjust the CSS values of the page:
https://github.com/kiwix/kiwix-apple/blob/c0539cc83bc7c2afb95ed95c6e5cc8bc94d01fc5/Views/BuildingBlocks/WebView.swift#L213-L220

## Proposed solution
I tried adjustments on the the swift view level, but that did not look good.

Therefore, I am proposing **to adjust the webkit padding** in a similar fashion as the text size increase is done for zooming in. 

As of my testing it looks good on all devices (iPhone, iPad, macOS).


