### PR TITLE
Change url type to be copied for macOS, remove id from menu

### DIFF
--- a/Support/br.lproj/Localizable.strings
+++ b/Support/br.lproj/Localizable.strings
@@ -55,7 +55,6 @@
 "library.zim_file_context.main_page.label" = "Degemer";
 "library.zim_file_context.random.label" = "Pajenn dre zegouezh";
 "library.zim_file_context.copy_url" = "Eilañ an URL";
-"library.zim_file_context.copy_id" = "Eilañ an ID";
 "zim_file_opened.overlay.no-opened.message" = "Restr ZIM digor ebet";
 "zim_file_opened.toolbar.show_sidebar.label" = "Diskouez ar varrenn-gostez";
 "zim_file_opened.toolbar.open.title" = "Digeriñ...";

--- a/Support/de.lproj/Localizable.strings
+++ b/Support/de.lproj/Localizable.strings
@@ -70,7 +70,6 @@
 "library.zim_file_context.main_page.label" = "Hauptseite";
 "library.zim_file_context.random.label" = "Zufällige Seite";
 "library.zim_file_context.copy_url" = "URL kopieren";
-"library.zim_file_context.copy_id" = "ID kopieren";
 "zim_file_opened.overlay.no-opened.message" = "Keine geöffnete ZIM-Datei";
 "zim_file_opened.toolbar.show_sidebar.label" = "Seitenleiste anzeigen";
 "zim_file_opened.toolbar.open.title" = "Öffnen…";

--- a/Support/en.lproj/Localizable.strings
+++ b/Support/en.lproj/Localizable.strings
@@ -98,7 +98,6 @@
 "library.zim_file_context.main_page.label" = "Main Page";
 "library.zim_file_context.random.label" = "Random Page";
 "library.zim_file_context.copy_url" = "Copy URL";
-"library.zim_file_context.copy_id" = "Copy ID";
 
 "zim_file_opened.overlay.no-opened.message" = "No opened ZIM file";
 "zim_file_opened.toolbar.show_sidebar.label" = "Show Sidebar";

--- a/Support/es.lproj/Localizable.strings
+++ b/Support/es.lproj/Localizable.strings
@@ -70,7 +70,6 @@
 "library.zim_file_context.main_page.label" = "Página principal";
 "library.zim_file_context.random.label" = "Página aleatoria";
 "library.zim_file_context.copy_url" = "Copiar enlace";
-"library.zim_file_context.copy_id" = "Copiar ID";
 "zim_file_opened.overlay.no-opened.message" = "No se ha abierto el archivo ZIM";
 "zim_file_opened.toolbar.show_sidebar.label" = "Mostrar barra lateral";
 "zim_file_opened.toolbar.open.title" = "Abrir...";

--- a/Support/fr.lproj/Localizable.strings
+++ b/Support/fr.lproj/Localizable.strings
@@ -80,7 +80,6 @@
 "library.zim_file_context.main_page.label" = "Page principale";
 "library.zim_file_context.random.label" = "Page au hasard";
 "library.zim_file_context.copy_url" = "Copier l’URL";
-"library.zim_file_context.copy_id" = "Copier l'identifiant";
 "zim_file_opened.overlay.no-opened.message" = "Aucun fichier ZIM ouvert";
 "zim_file_opened.toolbar.show_sidebar.label" = "Afficher la barre latérale";
 "zim_file_opened.toolbar.open.title" = "Ouvrir...";

--- a/Support/ha.lproj/Localizable.strings
+++ b/Support/ha.lproj/Localizable.strings
@@ -68,7 +68,6 @@
 "library.zim_file_context.main_page.label" = "Babban Shafi";
 "library.zim_file_context.random.label" = "Shafin bazuwar";
 "library.zim_file_context.copy_url" = "Kwafi URL";
-"library.zim_file_context.copy_id" = "Kawafi ID";
 "zim_file_opened.overlay.no-opened.message" = "Babu buddaden zim fayil";
 "zim_file_opened.toolbar.show_sidebar.label" = "Nuna ma'aunin gefe";
 "zim_file_opened.toolbar.open.title" = "Bude..";

--- a/Support/he.lproj/Localizable.strings
+++ b/Support/he.lproj/Localizable.strings
@@ -68,7 +68,6 @@
 "library.zim_file_context.main_page.label" = "עמוד ראשי";
 "library.zim_file_context.random.label" = "דף אקראי";
 "library.zim_file_context.copy_url" = "העתקת URL";
-"library.zim_file_context.copy_id" = "העתקת מזהה";
 "zim_file_opened.overlay.no-opened.message" = "לא נפתח קובץ ZIM";
 "zim_file_opened.toolbar.show_sidebar.label" = "הצגת סרגל צד";
 "zim_file_opened.toolbar.open.title" = "פתיחה...";

--- a/Support/ia.lproj/Localizable.strings
+++ b/Support/ia.lproj/Localizable.strings
@@ -67,7 +67,6 @@
 "library.zim_file_context.main_page.label" = "Pagina principal";
 "library.zim_file_context.random.label" = "Pagina aleatori";
 "library.zim_file_context.copy_url" = "Copiar URL";
-"library.zim_file_context.copy_id" = "Copiar ID";
 "zim_file_opened.overlay.no-opened.message" = "Necun file ZIM aperite";
 "zim_file_opened.toolbar.show_sidebar.label" = "Monstrar barra lateral";
 "zim_file_opened.toolbar.open.title" = "Aperir…";

--- a/Support/id.lproj/Localizable.strings
+++ b/Support/id.lproj/Localizable.strings
@@ -67,7 +67,6 @@
 "library.zim_file_context.main_page.label" = "Halaman Utama";
 "library.zim_file_context.random.label" = "Halaman Acak";
 "library.zim_file_context.copy_url" = "Salin URL";
-"library.zim_file_context.copy_id" = "Salin ID";
 "zim_file_opened.overlay.no-opened.message" = "Tidak ada berkas ZIM yang dibuka";
 "zim_file_opened.toolbar.show_sidebar.label" = "Tampilkan Bilah Sisi";
 "zim_file_opened.toolbar.open.title" = "Buka...";

--- a/Support/ig.lproj/Localizable.strings
+++ b/Support/ig.lproj/Localizable.strings
@@ -68,7 +68,6 @@
 "library.zim_file_context.main_page.label" = "Isi peeji";
 "library.zim_file_context.random.label" = "Peeji na enweghị usoro";
 "library.zim_file_context.copy_url" = "Kọpịa URL";
-"library.zim_file_context.copy_id" = "Kọia ID";
 // Fuzzy
 "zim_file_opened.overlay.no-opened.message" = "Enweghị faịlụ zim mepere emepe";
 "zim_file_opened.toolbar.show_sidebar.label" = "Gosi  akụkụ ihe ngosi";

--- a/Support/ja.lproj/Localizable.strings
+++ b/Support/ja.lproj/Localizable.strings
@@ -69,7 +69,6 @@
 "library.zim_file_context.main_page.label" = "メインページ";
 "library.zim_file_context.random.label" = "おまかせ表示";
 "library.zim_file_context.copy_url" = "URLをコピー";
-"library.zim_file_context.copy_id" = "IDをコピー";
 "zim_file_opened.overlay.no-opened.message" = "オープンしたZIMファイルはありません";
 "zim_file_opened.toolbar.show_sidebar.label" = "サイドバーを表示";
 "zim_file_opened.toolbar.open.title" = "開く...";

--- a/Support/ko.lproj/Localizable.strings
+++ b/Support/ko.lproj/Localizable.strings
@@ -63,7 +63,6 @@
 "library.zim_file_details.side_panel.message" = "상세 내용을 보려면 ZIM 파일을 선택하십시오";
 "library.zim_file_context.random.label" = "임의의 문서";
 "library.zim_file_context.copy_url" = "URL 복사";
-"library.zim_file_context.copy_id" = "ID 복사";
 "zim_file_opened.overlay.no-opened.message" = "열린 ZIM 파일이 없습니다";
 "zim_file_opened.toolbar.show_sidebar.label" = "사이드바 표시";
 "zim_file_opened.toolbar.open.title" = "열기...";

--- a/Support/lb.lproj/Localizable.strings
+++ b/Support/lb.lproj/Localizable.strings
@@ -55,7 +55,6 @@
 "library.zim_file_context.main_page.label" = "Haaptsäit";
 "library.zim_file_context.random.label" = "Zoufälleg Säit";
 "library.zim_file_context.copy_url" = "URL kopéieren";
-"library.zim_file_context.copy_id" = "ID kopéieren";
 "zim_file_opened.toolbar.open.title" = "Opmaachen...";
 "zim_file_opened.toolbar.open.help" = "ZIM-Fichier opmaachen";
 "zim_file_category.title" = "Kategorie";

--- a/Support/mk.lproj/Localizable.strings
+++ b/Support/mk.lproj/Localizable.strings
@@ -67,7 +67,6 @@
 "library.zim_file_context.main_page.label" = "Главна страница";
 "library.zim_file_context.random.label" = "Случајна страница";
 "library.zim_file_context.copy_url" = "Прекопирај URL";
-"library.zim_file_context.copy_id" = "Прекопирај назнака";
 "zim_file_opened.overlay.no-opened.message" = "Нема отворена ZIM-податотека";
 "zim_file_opened.toolbar.show_sidebar.label" = "Прикажи страничник";
 "zim_file_opened.toolbar.open.title" = "Open...";

--- a/Support/pt-br.lproj/Localizable.strings
+++ b/Support/pt-br.lproj/Localizable.strings
@@ -55,7 +55,6 @@
 "library.zim_file_context.main_page.label" = "Página principal";
 "library.zim_file_context.random.label" = "Página Aleatória";
 "library.zim_file_context.copy_url" = "Copiar URL";
-"library.zim_file_context.copy_id" = "Copiar ID";
 "zim_file_opened.toolbar.open.title" = "Abrir...";
 "zim_file_opened.toolbar.open.help" = "Abrir arquivo ZIM";
 "zim_file_category.title" = "Categoria";

--- a/Support/qqq.lproj/Localizable.strings
+++ b/Support/qqq.lproj/Localizable.strings
@@ -68,7 +68,6 @@
 "library.zim_file_context.main_page.label" = "Supplementary action title, when long pressing on a ZIM file";
 "library.zim_file_context.random.label" = "Supplementary action title, when long pressing on a ZIM file";
 "library.zim_file_context.copy_url" = "Suplementary action title, when long pressing a ZIM file.";
-"library.zim_file_context.copy_id" = "Supplementary action title, when long pressing on a ZIM file";
 "zim_file_opened.overlay.no-opened.message" = "Default placeholder text for center panel on macOS, when we have no history of opened files";
 "zim_file_opened.toolbar.show_sidebar.label" = "Show Sidebar";
 "zim_file_opened.toolbar.open.title" = "Accesissiblit label of a (+) icon on iOS, in the top right corner, to open a local file";

--- a/Support/ru.lproj/Localizable.strings
+++ b/Support/ru.lproj/Localizable.strings
@@ -73,7 +73,6 @@
 "library.zim_file_context.main_page.label" = "Заглавная страница";
 "library.zim_file_context.random.label" = "Случайная страница";
 "library.zim_file_context.copy_url" = "Скопировать URL-адрес";
-"library.zim_file_context.copy_id" = "Копировать идентификатор";
 "zim_file_opened.overlay.no-opened.message" = "Нет открытого ZIM-файла";
 "zim_file_opened.toolbar.show_sidebar.label" = "Показать боковую панель";
 "zim_file_opened.toolbar.open.title" = "Открыть...";

--- a/Support/sl.lproj/Localizable.strings
+++ b/Support/sl.lproj/Localizable.strings
@@ -63,7 +63,6 @@
 "library.zim_file_context.main_page.label" = "Glavna stran";
 "library.zim_file_context.random.label" = "Naključna stran";
 "library.zim_file_context.copy_url" = "Kopiraj URL";
-"library.zim_file_context.copy_id" = "Kopiraj ID";
 "zim_file_opened.overlay.no-opened.message" = "Odprta ni nobena datoteka ZIM";
 "zim_file_opened.toolbar.show_sidebar.label" = "Prikaži stransko vrstico";
 "zim_file_opened.toolbar.open.title" = "Odpri ...";

--- a/Support/sq.lproj/Localizable.strings
+++ b/Support/sq.lproj/Localizable.strings
@@ -67,7 +67,6 @@
 "library.zim_file_context.main_page.label" = "Faqja Kryesore";
 "library.zim_file_context.random.label" = "Faqe Kuturu";
 "library.zim_file_context.copy_url" = "Kopjo URL-në";
-"library.zim_file_context.copy_id" = "Kopjo ID-në";
 "zim_file_opened.overlay.no-opened.message" = "S’ka kartelë ZIM të hapur";
 "zim_file_opened.toolbar.show_sidebar.label" = "Shfaq Anështyllë";
 "zim_file_opened.toolbar.open.title" = "Hapni…";

--- a/Support/sv.lproj/Localizable.strings
+++ b/Support/sv.lproj/Localizable.strings
@@ -70,7 +70,6 @@
 "library.zim_file_context.main_page.label" = "Huvudsida";
 "library.zim_file_context.random.label" = "Slumpsida";
 "library.zim_file_context.copy_url" = "Kopiera webbadress";
-"library.zim_file_context.copy_id" = "Kopiera ID";
 "zim_file_opened.overlay.no-opened.message" = "Ingen öppnad ZIM-fil";
 "zim_file_opened.toolbar.show_sidebar.label" = "Visa sidofält";
 "zim_file_opened.toolbar.open.title" = "Öppna...";

--- a/Support/tr.lproj/Localizable.strings
+++ b/Support/tr.lproj/Localizable.strings
@@ -64,7 +64,6 @@
 "library.zim_file_context.main_page.label" = "Anasayfa";
 "library.zim_file_context.random.label" = "Rastgele Sayfa";
 "library.zim_file_context.copy_url" = "URL'yi kopyala";
-"library.zim_file_context.copy_id" = "Kimliği kopyala";
 // Fuzzy
 "zim_file_opened.overlay.no-opened.message" = "Açık zim dosyası yok";
 "zim_file_opened.toolbar.show_sidebar.label" = "Kenar Çubuğunu Göster";

--- a/Support/uk.lproj/Localizable.strings
+++ b/Support/uk.lproj/Localizable.strings
@@ -63,7 +63,6 @@
 "library.zim_file_context.main_page.label" = "Головна сторінка";
 "library.zim_file_context.random.label" = "Випадкова сторінка";
 "library.zim_file_context.copy_url" = "Скопіювати URL";
-"library.zim_file_context.copy_id" = "Скопіювати ID";
 "zim_file_opened.overlay.no-opened.message" = "Немає відкритого файлу ZIM";
 "zim_file_opened.toolbar.show_sidebar.label" = "Показати бічну панель";
 "zim_file_opened.toolbar.open.title" = "Відкрити...";

--- a/Support/zh-hans.lproj/Localizable.strings
+++ b/Support/zh-hans.lproj/Localizable.strings
@@ -72,7 +72,6 @@
 "library.zim_file_context.main_page.label" = "首页";
 "library.zim_file_context.random.label" = "随机页面";
 "library.zim_file_context.copy_url" = "复制URL";
-"library.zim_file_context.copy_id" = "复制 ID";
 "zim_file_opened.overlay.no-opened.message" = "没有打开任何 ZIM 文件";
 "zim_file_opened.toolbar.show_sidebar.label" = "显示侧边栏";
 "zim_file_opened.toolbar.open.title" = "打开...";

--- a/Support/zh-hant.lproj/Localizable.strings
+++ b/Support/zh-hant.lproj/Localizable.strings
@@ -68,7 +68,6 @@
 "library.zim_file_context.main_page.label" = "主頁";
 "library.zim_file_context.random.label" = "隨機頁面";
 "library.zim_file_context.copy_url" = "複製 URL";
-"library.zim_file_context.copy_id" = "複製 ID";
 "zim_file_opened.overlay.no-opened.message" = "沒有開啟的 ZIM 檔案";
 "zim_file_opened.toolbar.show_sidebar.label" = "顯示側邊欄";
 "zim_file_opened.toolbar.open.title" = "開啟…";

--- a/Views/Library/Library.swift
+++ b/Views/Library/Library.swift
@@ -169,23 +169,13 @@ struct LibraryZimFileContext: ViewModifier {
             Button {
                 #if os(macOS)
                 NSPasteboard.general.clearContents()
-                NSPasteboard.general.setString(downloadURL.absoluteString, forType: .URL)
+                NSPasteboard.general.setString(downloadURL.absoluteString, forType: .string)
                 #elseif os(iOS)
                 UIPasteboard.general.setValue(downloadURL.absoluteString, forPasteboardType: UTType.url.identifier)
                 #endif
             } label: {
                 Label(LocalString.library_zim_file_context_copy_url, systemImage: "doc.on.doc")
             }
-        }
-        Button {
-            #if os(macOS)
-            NSPasteboard.general.clearContents()
-            NSPasteboard.general.setString(zimFile.fileID.uuidString, forType: .string)
-            #elseif os(iOS)
-            UIPasteboard.general.setValue(zimFile.fileID.uuidString, forPasteboardType: UTType.plainText.identifier)
-            #endif
-        } label: {
-            Label(LocalString.library_zim_file_context_copy_id, systemImage: "barcode.viewfinder")
         }
     }
 }


### PR DESCRIPTION
Fixes: #1099 

macOS (right clicking on a catalog item)
<img width="423" alt="Screenshot 2025-02-07 at 11 45 39" src="https://github.com/user-attachments/assets/199d013b-37c2-4cf3-8af9-22ef8dc1ef63" />

iOS (long pressing on a catalog item)
![Screenshot 2025-02-07 at 11 47 03](https://github.com/user-attachments/assets/ca813e2a-66f2-4dbc-97e2-9250a0934902)
