### PR TITLE
Fix iOS build and use iOS 18.1 simulators on Xcode 16.2

### DIFF
--- a/.github/actions/xcbuild/action.yml
+++ b/.github/actions/xcbuild/action.yml
@@ -116,6 +116,10 @@ runs:
       shell: bash
       run: xcrun xcodebuild -workspace $XC_WORKSPACE -scheme $XC_SCHEME -showBuildSettings
 
+    - name: Show eligible build destinations for the ${{ inputs.XC_SCHEME }}
+      shell: bash
+      run: xcrun xcodebuild -showdestinations -scheme ${{ inputs.XC_SCHEME }}
+
     - name: Build with Xcode
       env:
         ACTION: ${{ inputs.action }}

--- a/.github/actions/xcbuild/action.yml
+++ b/.github/actions/xcbuild/action.yml
@@ -58,6 +58,18 @@ runs:
       # https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md#xcode
       run: sudo xcode-select -s /Applications/Xcode_15.2.0.app
 
+    - name: Use specific iOS SDK
+      env:
+        DEST: ${{ inputs.xc-destination }}
+        IOS_SDK: "18.1"
+      shell: bash
+      run: |
+        if [[ "$DEST" =~ "iOS" ]]; then
+          echo "XC_DEST_OS=;OS=$IOS_SDK" >> $GITHUB_ENV
+        else
+          echo "XC_DEST_OS=" >> $GITHUB_ENV
+        fi
+
     - name: Create Keychain
       shell: bash
       env:
@@ -111,7 +123,7 @@ runs:
         XC_WORKSPACE: ${{ inputs.XC_WORKSPACE }}
         XC_SCHEME: ${{ inputs.XC_SCHEME }}
         XC_CONFIG: ${{ inputs.XC_CONFIG }}
-        XC_DESTINATION: ${{ inputs.xc-destination }}
+        XC_DESTINATION: ${{ inputs.xc-destination }}${{ env.XC_DEST_OS }}
         EXTRA_XCODEBUILD: ${{ inputs.EXTRA_XCODEBUILD }}
       shell: bash
       run: xcrun xcodebuild ${EXTRA_XCODEBUILD} -workspace $XC_WORKSPACE -scheme $XC_SCHEME -destination "$XC_DESTINATION" -configuration $XC_CONFIG -onlyUsePackageVersionsFromResolvedFile -allowProvisioningUpdates -verbose -archivePath $PWD/Kiwix-$VERSION.xcarchive ${ACTION}


### PR DESCRIPTION
The former PR updating to Xcode 16.2, made the [build fail](https://github.com/kiwix/kiwix-apple/actions/runs/13473510711).
Reason being is that the default iOS SDK for simulators in Xcode 16.2 is the "latest", which is currently iOS 18.2. The issue is that Github runners (macOS-14) do not have that pre-installed yet, so we need to fall back to simulators running iOS 18.1, which is installed:
https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md

well it's still not ok, maybe it's because non of the simulators are pre-installed as per Apple: 
https://developer.apple.com/documentation/xcode-release-notes/xcode-16-release-notes

I am not convinced at this point to do this update, if we need to download the simulator environment for every single build we run on GitHub Actions ...
