### PR TITLE
Fix PhET initial webpage to be on screen for html canvas calculations

### DIFF
--- a/Views/BrowserTab.swift
+++ b/Views/BrowserTab.swift
@@ -184,27 +184,30 @@ struct BrowserTab: View {
                             #endif
                     } else {
                         switch model.state {
-                        case .loadingData:
-                            LoadingDataView()
-                        case .webPage(let isLoading):
-                            WebView(browser: browser)
-                                .ignoresSafeArea()
-                                .overlay {
-                                    if isLoading {
-                                        LoadingProgressView()
+                        case .loadingData, .webPage:
+                            ZStack {
+                                LoadingDataView()
+                                    .opacity(model.state == .loadingData ? 1.0 : 0.0)
+                                WebView(browser: browser)
+                                    .opacity(model.state == .loadingData ? 0.0 : 1.0)
+                                    .ignoresSafeArea()
+                                    .overlay {
+                                        if case .webPage(let isLoading) = model.state, isLoading {
+                                            LoadingProgressView()
+                                        }
                                     }
-                                }
 #if os(macOS)
-                                .overlay(alignment: .bottomTrailing) {
-                                    if !Brand.hideFindInPage {
-                                        ContentSearchBar(
-                                            model: ContentSearchViewModel(
-                                                findInWebPage: browser.webView.find(_:configuration:)
+                                    .overlay(alignment: .bottomTrailing) {
+                                        if !Brand.hideFindInPage {
+                                            ContentSearchBar(
+                                                model: ContentSearchViewModel(
+                                                    findInWebPage: browser.webView.find(_:configuration:)
+                                                )
                                             )
-                                        )
+                                        }
                                     }
-                                }
 #endif
+                            }
                         case .catalog(.fetching):
                             FetchingCatalogView()
                         case .catalog(.list):


### PR DESCRIPTION
Fixes: #1205 

## The problem
My investigation lead me to the following conclusions. This problem occurs only on app start, and not always.
It is a timing issue. What we do is displaying the initial "loading data..." state, and in the meantime we start loading the web content, once the content is loaded (in full), we display the web view. This works fine for most content but not for PhET.
The reason being, is that PhET subpages (we want to restore), are using javascript to draw on ad-hoc canvases, but that fails if the web view is off-screen (hasn't been added yet to the view hierarchy on iOS).

## Solution:
Add the web-view to the view hierarchy up-front, but make it invisible, and once we switch states from "Loading data...", swap around the opacity. This way the canvas drawing can be done properly.
