### PR TITLE
Remove horizontal divider line from Hotspot screen

### DIFF
--- a/Views/Hotspot/HotspotZimFilesSelection.swift
+++ b/Views/Hotspot/HotspotZimFilesSelection.swift
@@ -48,7 +48,6 @@ struct HotspotZimFilesSelection: View {
     
     var body: some View {
         VStack(spacing: 0) {
-            Divider()
             LazyVGrid(
                 columns: ([GridItem(.adaptive(minimum: 250, maximum: 500), spacing: 12)]),
                 alignment: .leading,


### PR DESCRIPTION
Fixes: #1250 

<img width="2752" height="2064" alt="simulator_screenshot_693F2C46-3403-4A7E-90B8-3F778914DB66" src="https://github.com/user-attachments/assets/c6648ad7-49e9-4071-8d9a-3bae75334403" />
