### PR TITLE
Update Apple-Pay to 24.23.0

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -49,7 +49,7 @@ packages:
     majorVersion: 8.2.0
   StripeApplePay:
     url: https://github.com/CodeLikeW/stripe-apple-pay
-    majorVersion: 24.0.0
+    majorVersion: 24.23.0
 
 targetTemplates:
   ApplicationTemplate:


### PR DESCRIPTION
Fixes: #1289

Updating our Apple-Pay dependency to 24.23.0 (latest stripe code).
On the kiwix side, it's an easy change.
The full list changes are in these 2 repos:
https://github.com/CodeLikeW/stripe-apple-pay/compare/24.0.0...24.23.0
https://github.com/CodeLikeW/stripe-core/compare/24.0.0...24.23.0