### PR TITLE
Exclude missing ZIM files from search options

### DIFF
--- a/ViewModel/SearchViewModel.swift
+++ b/ViewModel/SearchViewModel.swift
@@ -34,7 +34,7 @@ final class SearchViewModel: NSObject, ObservableObject, NSFetchedResultsControl
     override private init() {
         // initialize fetched results controller
         let predicate = NSPredicate(
-            format: "includedInSearch == true AND fileURLBookmark != nil AND isMissing != false"
+            format: "includedInSearch == true AND fileURLBookmark != nil"
         )
         fetchedResultsController = NSFetchedResultsController(
             fetchRequest: ZimFile.fetchRequest(predicate: predicate),

--- a/Views/SearchResults.swift
+++ b/Views/SearchResults.swift
@@ -28,7 +28,7 @@ struct SearchResults: View {
     @FocusState private var focusedSearchItem: URL? // macOS only
     @FetchRequest(
         sortDescriptors: [NSSortDescriptor(keyPath: \ZimFile.size, ascending: false)],
-        predicate: ZimFile.openedPredicate,
+        predicate: ZimFile.Predicate.isDownloaded,
         animation: .easeInOut
     ) private var zimFiles: FetchedResults<ZimFile>
 
@@ -169,11 +169,11 @@ struct SearchResults: View {
                     ForEach(zimFiles) { zimFile in
                         HStack {
                             Toggle(zimFile.name, isOn: Binding<Bool>(get: {
-                                zimFile.includedInSearch
+                                zimFile.includedInSearch && !zimFile.isMissing
                             }, set: {
                                 zimFile.includedInSearch = $0
                                 try? managedObjectContext.save()
-                            }))
+                            })).disabled(zimFile.isMissing)
                             Spacer()
                         }
                     }


### PR DESCRIPTION
Fixes: #1325

Make sure we exclude the missing ZIM files from search results:

<img width="320" height="228" alt="Screenshot 2025-10-09 at 23 24 31 Medium" src="https://github.com/user-attachments/assets/222a6b52-43cc-4a59-b1e9-2f03ebc7a3e8" />

<img width="320" height="228" alt="Screenshot 2025-10-09 at 23 24 47 Medium" src="https://github.com/user-attachments/assets/e5f6efa0-3926-4194-8041-47684551ad7f" />

