### PR TITLE
Don't display no search results, if there's no search input

### DIFF
--- a/Views/SearchResults.swift
+++ b/Views/SearchResults.swift
@@ -86,7 +86,11 @@ struct SearchResults: View {
                 Spacer()
             }
         } else if viewModel.results.isEmpty {
-            Message(text: LocalString.search_result_zimfile_no_result_message)
+            if viewModel.searchText.isEmpty {
+                Spacer()
+            } else {
+                Message(text: LocalString.search_result_zimfile_no_result_message)
+            }
         } else {
             ScrollViewReader { scrollReader in
                 ScrollView {


### PR DESCRIPTION
Fixes: #1348

Using an empty view, if there's no user input in the search field:

<img width="320" height="213" alt="Screenshot 2025-11-01 at 15 28 00 Medium" src="https://github.com/user-attachments/assets/a7cc1caa-8264-4eab-9db5-484c7a1b058c" />


<img width="320" height="213" alt="Screenshot 2025-11-01 at 15 28 11 Medium" src="https://github.com/user-attachments/assets/1d27e7e2-d1c9-494d-a3f0-fd2a0dfa1637" />

