### PR TITLE
Fix extreme time trying to load favicon data

### DIFF
--- a/Model/Entities/ZimFileMetaData/ZimFileMetaData.mm
+++ b/Model/Entities/ZimFileMetaData/ZimFileMetaData.mm
@@ -157,16 +157,20 @@
 }
 
 - (NSData * _Nullable)getFaviconDataFromBook:(kiwix::Book *)book {
-    try {
-        std::string dataString = book->getIllustrations().at(0)->getData();
-        if(dataString.length() == 0) {
-            return nil;
-        }
-        NSData *favIconData = [NSData dataWithBytes: dataString.data() length: dataString.length()];
-        return favIconData;
-    } catch (std::exception) {
-        return nil;
-    }
+    return nil;
+    // this was never returning any data (always nil)
+    // but since libkiwix 14.1 it takes a huge amount of time even trying it
+    // so better not to even try, until it's not fixed
+//    try {
+//        std::string dataString = book->getIllustrations().at(0)->getData();
+//        if(dataString.length() == 0) {
+//            return nil;
+//        }
+//        NSData *favIconData = [NSData dataWithBytes: dataString.data() length: dataString.length()];
+//        return favIconData;
+//    } catch (std::exception) {
+//        return nil;
+//    }
 }
 
 - (NSString *)getFlavorFromBook:(kiwix::Book *)book {


### PR DESCRIPTION
Related to: #1352 

There's a clear regression issue in libkiwix 14.1.

## Context
We have this call:
```objective-c
book->getIllustrations().at(0)->getData();
```

It suppose to return the favicons image data. We are calling it as part of fetching the catalog. In reality, it never returns any data, but that's nothing new, it wasn't returning any data as of libkiwix 14.0.1 either.
(see related past issues: https://github.com/kiwix/libkiwix/issues/1180, I am not sure if that was meant to be fixed)

## The problem
The real problem is **how long it tries** to do return that data (even-though the result is always nil).
I've checked the commit merging libkiwix 14.1, and the one right before, and compared the builds from both by running fresh installs on iPad.
On **libkiwix 14.0.1** the average time to fetch the catalog is about **20 sec.**
On **libkiwix 14.1,** I got fed up measuring it when it went **over 1 minute 30 sec** (and still not finished doing it).

## Solution
If we bypass this call, and return directly ``nil``, the outcome will be the same, but we don't need to wait for it, and we get back to our expected ~20 seconds loading time.