### PR TITLE
Fix download task out of sync with zimFile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 3.11.1
   - NEW:
     - ZIM file validation feature(@BPerlakiH #1379)
+  - FIX:
+    - macOS crash when opening downloads tab (@BPerlakiH #1383)
 # 3.11.0
   - NEW:
     - Hotspot for custom apps (@BPerlakiH #1331)

--- a/Model/Entities/Entities.swift
+++ b/Model/Entities/Entities.swift
@@ -37,22 +37,20 @@ class Bookmark: NSManagedObject, Identifiable {
     }
 }
 
-class DownloadTask: NSManagedObject, Identifiable {
-    var id: UUID { fileID }
-
+final class DownloadTask: NSManagedObject {
     @NSManaged var created: Date
     @NSManaged var error: String?
     @NSManaged var fileID: UUID
     @NSManaged var zimFile: ZimFile?
 
-    class func fetchRequest(predicate: NSPredicate? = nil) -> NSFetchRequest<DownloadTask> {
+    static func fetchRequest(predicate: NSPredicate? = nil) -> NSFetchRequest<DownloadTask> {
         // swiftlint:disable:next force_cast
         let request = super.fetchRequest() as! NSFetchRequest<DownloadTask>
         request.predicate = predicate
         return request
     }
 
-    class func fetchRequest(fileID: UUID) -> NSFetchRequest<DownloadTask> {
+    static func fetchRequest(fileID: UUID) -> NSFetchRequest<DownloadTask> {
         // swiftlint:disable:next force_cast
         let request = super.fetchRequest() as! NSFetchRequest<DownloadTask>
         request.predicate = NSPredicate(format: "fileID == %@", fileID as CVarArg)
@@ -247,9 +245,7 @@ struct DirectAccessInfo {
     }
 }
 
-final class ZimFile: NSManagedObject, Identifiable {
-    var id: UUID { fileID }
-
+final class ZimFile: NSManagedObject {
     @NSManaged var articleCount: Int64
     @NSManaged var category: String
     @NSManaged var created: Date

--- a/Tests/LibraryRefreshViewModelTest.swift
+++ b/Tests/LibraryRefreshViewModelTest.swift
@@ -209,12 +209,11 @@ final class LibraryRefreshViewModelTest: XCTestCase {
         // check one zim file is in the database
         let zimFiles = try context.fetchZimFiles()
         XCTAssertEqual(zimFiles.count, 1)
-        XCTAssertEqual(zimFiles[0].id, zimFileID)
+        XCTAssertEqual(zimFiles[0].fileID, zimFileID)
 
         // check zim file can be retrieved by id, and properties are populated
         // swiftlint:disable:next force_try
         let zimFile = try! XCTUnwrap(zimFiles.first { $0.fileID == zimFileID })
-        XCTAssertEqual(zimFile.id, zimFileID)
         XCTAssertEqual(zimFile.articleCount, 50001)
         XCTAssertEqual(zimFile.category, Category.wikipedia.rawValue)
         // swiftlint:disable:next force_try

--- a/Views/BuildingBlocks/DownloadTaskCell.swift
+++ b/Views/BuildingBlocks/DownloadTaskCell.swift
@@ -73,7 +73,7 @@ struct DownloadTaskCell: View {
         .clipShape(CellBackground.clipShapeRectangle)
         .onHover { self.isHovering = $0 }
         .onReceive(DownloadService.shared.progress.publisher) { states in
-            if let state = states[downloadZimFile.fileID] {
+            if !states.isEmpty, let state = states[downloadZimFile.fileID] {
                 self.downloadState = state
             }
         }

--- a/Views/Buttons/ArticleShortcutButtons.swift
+++ b/Views/Buttons/ArticleShortcutButtons.swift
@@ -52,7 +52,7 @@ struct ArticleShortcutButtons: View {
         .help(LocalString.article_shortcut_main_button_help)
         #elseif os(iOS)
         Menu {
-            ForEach(zimFiles) { zimFile in
+            ForEach(zimFiles, id: \.fileID) { zimFile in
                 Button(zimFile.name) {
                     loadMainArticle(zimFile.fileID)
                     dismissSearch()
@@ -83,7 +83,7 @@ struct ArticleShortcutButtons: View {
 
         #elseif os(iOS)
         Menu {
-            ForEach(zimFiles) { zimFile in
+            ForEach(zimFiles, id: \.fileID) { zimFile in
                 Button(zimFile.name) {
                     loadRandomArticle(zimFile.fileID)
                     dismissSearch()

--- a/Views/Hotspot/HotspotZimFilesSelection.swift
+++ b/Views/Hotspot/HotspotZimFilesSelection.swift
@@ -73,7 +73,7 @@ struct HotspotZimFilesSelection: View {
                         alignment: .center,
                         spacing: 12
                     ) {
-                        ForEach(zimFiles) { zimFile in
+                        ForEach(zimFiles, id: \.fileID) { zimFile in
                             MultiZimFilesSelectionContext(
                                 content: {
                                     ZimFileCell(

--- a/Views/Library/ZimFileDetail/ZimFileDetail.swift
+++ b/Views/Library/ZimFileDetail/ZimFileDetail.swift
@@ -142,7 +142,7 @@ struct ZimFileDetail: View {
             #endif
             #if os(macOS)
             Action(title: LocalString.zim_file_action_reveal_in_finder_title) {
-                guard let url = await ZimFileService.shared.getFileURL(zimFileID: zimFile.id) else { return }
+                guard let url = await ZimFileService.shared.getFileURL(zimFileID: zimFile.fileID) else { return }
                 NSWorkspace.shared.activateFileViewerSelecting([url])
             }
             #endif
@@ -258,7 +258,8 @@ struct ZimFileDetail: View {
             if let freeSpace = freeSpace, zimFile.size >= freeSpace - 10^9 {
                 isPresentingDownloadAlert = true
             } else {
-                DownloadService.shared.start(zimFileID: zimFile.id, allowsCellularAccess: downloadUsingCellular)
+                DownloadService.shared.start(zimFileID: zimFile.fileID,
+                                             allowsCellularAccess: downloadUsingCellular)
             }
         }.alert(isPresented: $isPresentingDownloadAlert) {
             Alert(
@@ -272,7 +273,7 @@ struct ZimFileDetail: View {
                 }()),
                 primaryButton: .default(Text(LocalString.zim_file_action_download_button_anyway)) {
                     DownloadService.shared.start(
-                        zimFileID: zimFile.id,
+                        zimFileID: zimFile.fileID,
                         allowsCellularAccess: downloadUsingCellular
                     )
                 },

--- a/Views/Library/ZimFilesCategories.swift
+++ b/Views/Library/ZimFilesCategories.swift
@@ -129,7 +129,7 @@ private struct CategoryGrid: View {
                 LazyVGrid(columns: ([gridItem]), alignment: .leading, spacing: 12) {
                     ForEach(sections) { section in
                         Section {
-                            ForEach(section) { zimFile in
+                            ForEach(section, id: \.fileID) { zimFile in
                                 LibraryZimFileContext(
                                     content: { ZimFileCell(
                                         zimFile,

--- a/Views/Library/ZimFilesDownloads.swift
+++ b/Views/Library/ZimFilesDownloads.swift
@@ -22,6 +22,7 @@ struct ZimFilesDownloads: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @FetchRequest(
         sortDescriptors: [NSSortDescriptor(keyPath: \DownloadTask.created, ascending: false)],
+        predicate: NSPredicate(format: "zimFile != NULL"),
         animation: .easeInOut
     ) private var downloadTasks: FetchedResults<DownloadTask>
     private let dismiss: (() -> Void)?
@@ -36,12 +37,14 @@ struct ZimFilesDownloads: View {
             alignment: .leading,
             spacing: 12
         ) {
-            ForEach(downloadTasks.compactMap(\.zimFile)) { zimFile in
-                LibraryZimFileContext(
-                    content: { DownloadTaskCell(zimFile) },
-                    zimFile: zimFile,
-                    selection: selection,
-                    dismiss: dismiss)
+            ForEach(downloadTasks, id: \.fileID) { downloadTask in
+                if let zimFile = downloadTask.zimFile, zimFile.downloadTask != nil {
+                    LibraryZimFileContext(
+                        content: { DownloadTaskCell(zimFile) },
+                        zimFile: zimFile,
+                        selection: selection,
+                        dismiss: dismiss)
+                }
             }
         }
         .modifier(GridCommon())

--- a/Views/Library/ZimFilesMultiOpened.swift
+++ b/Views/Library/ZimFilesMultiOpened.swift
@@ -38,7 +38,7 @@ struct ZimFilesMultiOpened: View {
                 alignment: .leading,
                 spacing: 12
             ) {
-                ForEach(zimFiles) { zimFile in
+                ForEach(zimFiles, id: \.fileID) { zimFile in
                     MultiZimFilesContext(
                         content: {
                             ZimFileCell(

--- a/Views/Library/ZimFilesOpened.swift
+++ b/Views/Library/ZimFilesOpened.swift
@@ -51,7 +51,7 @@ struct ZimFilesOpened: View {
             alignment: .leading,
             spacing: 12
         ) {
-            ForEach(zimFiles) { zimFile in
+            ForEach(zimFiles, id: \.fileID) { zimFile in
                 NavigationLink {
                     ZimFileDetail(zimFile: zimFile, dismissParent: nil)
                 } label: {

--- a/Views/Library/ZimFilesOpenedNavStack.swift
+++ b/Views/Library/ZimFilesOpenedNavStack.swift
@@ -42,7 +42,7 @@ struct ZimFilesOpenedNavStack: View {
                 alignment: .leading,
                 spacing: 12
             ) {
-                ForEach(zimFiles) { zimFile in
+                ForEach(zimFiles, id: \.fileID) { zimFile in
                     NavigationLink(value: zimFile) {
                         ZimFileCell(
                             zimFile,

--- a/Views/LocalLibraryList.swift
+++ b/Views/LocalLibraryList.swift
@@ -41,7 +41,7 @@ struct LocalLibraryList: View {
             spacing: 12
         ) {
             GridSection(title: LocalString.welcome_main_page_title) {
-                ForEach(zimFiles) { zimFile in
+                ForEach(zimFiles, id: \.fileID) { zimFile in
                     AsyncButtonView {
                         guard let url = await ZimFileService.shared
                             .getMainPageURL(zimFileID: zimFile.fileID) else { return }

--- a/Views/SearchResults.swift
+++ b/Views/SearchResults.swift
@@ -214,7 +214,7 @@ struct SearchResults: View {
             }
             if FeatureFlags.hasLibrary {
                 Section {
-                    ForEach(zimFiles) { zimFile in
+                    ForEach(zimFiles, id: \.fileID) { zimFile in
                         HStack {
                             Toggle(zimFile.name, isOn: Binding<Bool>(get: {
                                 zimFile.includedInSearch && !zimFile.isMissing


### PR DESCRIPTION
Fixes: #1380

I managed to reproduce this.

## Issue:
The download tasks could go out of sync with the list of ZIM files in the DB, resulting in a crash.

## Solution:
Make sure we are only listing valid download tasks (not faulting ones).

There were some additional getters for zimFileId that was only masking the problem and made it harder to pin down, so I removed those, and made it more explicit.
