### PR TITLE
Disable download pause for mid-state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
     - ZIM file validation feature(@BPerlakiH #1379)
   - FIX:
     - macOS crash when opening downloads tab (@BPerlakiH #1383)
+    - Immediate pause of downloads (@BPerlakiH #1385)
 # 3.11.0
   - NEW:
     - Hotspot for custom apps (@BPerlakiH #1331)

--- a/Views/Library/ZimFileDetail/DownloadTaskDetail.swift
+++ b/Views/Library/ZimFileDetail/DownloadTaskDetail.swift
@@ -39,7 +39,7 @@ extension ZimFileDetail {
                 } else if downloadState.resumeData == nil {
                     Action(title: LocalString.zim_file_download_task_action_pause) {
                         DownloadService.shared.pause(zimFileID: downloadZimFile.fileID)
-                    }
+                    }.disabled(downloadState.downloaded == 0) // make sure cannot be paused mid-state
                     Attribute(title: LocalString.zim_file_download_task_action_downloading, detail: detail)
                 } else {
                     Action(title: LocalString.zim_file_download_task_action_resume) {


### PR DESCRIPTION
Fixes: #1384 

The easiest solution for now, is to disable the pause button for this mid state between pressing the download button and the progress really starting.