### PR TITLE
Use date in kiwix diagnostic output file name

### DIFF
--- a/Model/Diagnostics.swift
+++ b/Model/Diagnostics.swift
@@ -54,6 +54,13 @@ enum Diagnostics {
         return logs
     }
     
+    public static func fileName(using date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withDashSeparatorInDate, .withFullDate]
+        let dateString = formatter.string(from: date)
+        return "kiwix_diagnostic_\(dateString)"
+    }
+    
     private static func appVersion() -> String {
         let unknown = "unknown"
         let bundle = Bundle.main

--- a/Views/Settings/DiagnosticsView.swift
+++ b/Views/Settings/DiagnosticsView.swift
@@ -99,7 +99,7 @@ struct DiagnosticsView: View {
             guard let data = logs.data(using: .utf8) else { return }
             let panel = NSSavePanel()
             panel.allowedContentTypes = [.log]
-            panel.nameFieldStringValue = "diagnostics.log"
+            panel.nameFieldStringValue = "\(Diagnostics.fileName(using: Date())).txt"
             if case .OK = panel.runModal(),
                let targetURL = panel.url {
                 try? data.write(to: targetURL)
@@ -119,7 +119,11 @@ struct DiagnosticsView: View {
             await validateRemainingZIMFiles()
             let logs = await Diagnostics.entries(separator: "\n")
             guard let data = logs.data(using: .utf8) else { return }
-            let exportData = FileExportData(data: data, fileName: "diagnostic", fileExtension: "log")
+            let exportData = FileExportData(
+                data: data,
+                fileName: Diagnostics.fileName(using: Date()),
+                fileExtension: "txt"
+            )
             NotificationCenter.exportFileData(exportData)
         } label: {
             Label("Share", systemImage: "square.and.arrow.up")


### PR DESCRIPTION
Related to: #1391 

Solving:
> When the diagnostic is saved to a file it should be called "kiwix_diagnostic_mm-dd-yyyy.txt".

