### PR TITLE
Fix reopening app with zim files from crashing

### DIFF
--- a/SwiftUI/Model/LibraryOperations.swift
+++ b/SwiftUI/Model/LibraryOperations.swift
@@ -49,9 +49,9 @@ struct LibraryOperations {
             LibraryOperations.configureZimFile(zimFile, metadata: metadata)
             zimFile.fileURLBookmark = fileURLBookmark
             zimFile.isMissing = false
-            if context.hasChanges { try? context.save() }
             Task {
                 await MainActor.run {
+                    if context.hasChanges { try? context.save() }
                     onComplete?()
                 }
             }


### PR DESCRIPTION
Relates to: #1400 

The database view context meant to be run on the main thread.