### PR TITLE
Display progress while searching

### DIFF
--- a/Views/SearchResults.swift
+++ b/Views/SearchResults.swift
@@ -76,8 +76,12 @@ struct SearchResults: View {
         if case SearchResultItems.results([]) = viewModel.results {
             if viewModel.searchText.isEmpty {
                 Spacer()
-            } else { 
-                Message(text: LocalString.search_result_zimfile_no_result_message)
+            } else {
+                if viewModel.inProgress {
+                    ProgressView()
+                } else {
+                    Message(text: LocalString.search_result_zimfile_no_result_message)
+                }
             }
         } else {
             ScrollViewReader { scrollReader in


### PR DESCRIPTION
Fixes: #1425 

We had the progress view only displaying while there were former search results displayed, and the user was searching (eg: kept typing).
This also covers the case, when we start the searching from scratch.
