### PR TITLE
Use our localisation for search input

### DIFF
--- a/Views/Library/ZimFilesCategories.swift
+++ b/Views/Library/ZimFilesCategories.swift
@@ -169,7 +169,7 @@ private struct CategoryGrid: View {
                 }.modifier(GridCommon())
             }
         }
-        .searchable(text: $searchText)
+        .searchable(text: $searchText, prompt: LocalString.common_search)
         .onChange(of: category) { selection.reset() }
         .onChange(of: searchText) { _, newValue in
             sections.nsPredicate = ZimFilesCategory.buildPredicate(category: category, searchText: newValue)
@@ -259,7 +259,7 @@ private struct CategoryList: View {
                 #endif
             }
         }
-        .searchable(text: $searchText)
+        .searchable(text: $searchText, prompt: LocalString.common_search)
         .onChange(of: category) { selection.reset() }
         .onChange(of: searchText) { _, newValue in
             zimFiles.nsPredicate = ZimFilesCategory.buildPredicate(category: category, searchText: newValue)

--- a/Views/Library/ZimFilesNew.swift
+++ b/Views/Library/ZimFilesNew.swift
@@ -127,7 +127,7 @@ struct ZimFilesNew: View {
         .modifier(GridCommon())
         .modifier(ToolbarRoleBrowser())
         .navigationTitle(MenuItem.new.name)
-        .searchable(text: $searchText)
+        .searchable(text: $searchText, prompt: LocalString.common_search)
         .onAppear {
             viewModel.update(searchText: searchText)
             viewModel.update(languageCodes: languageCodes)


### PR DESCRIPTION
Fixes: #1437 

It turns out that if we use Apple built in localisation for the Search, it's not the same value:

![Screenshot 2026-01-24 at 10 27 44 Large](https://github.com/user-attachments/assets/b232ff31-68da-40a4-bd29-0fe45b0828f7)
