### PR TITLE
Update build settings to Xcode 26.1.1

### DIFF
--- a/.github/actions/xcbuild/action.yml
+++ b/.github/actions/xcbuild/action.yml
@@ -53,10 +53,10 @@ runs:
           -T /usr/bin/security \
           -T /usr/bin/productbuild || true
 
-    - name: Set Xcode version (26.0.1)
+    - name: Set Xcode version (26.1.1)
       shell: bash
-      # https://github.com/actions/runner-images/blob/macos-15-arm64/20250928.2397/images/macos/macos-15-arm64-Readme.md#xcode
-      run: sudo xcode-select -s /Applications/Xcode_26.0.1.app
+      # https://github.com/actions/runner-images/blob/main/images/macos/macos-15-arm64-Readme.md#installed-sdks
+      run: sudo xcode-select -s /Applications/Xcode_26.1.1.app
 
     - name: Create Keychain
       shell: bash

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -122,7 +122,7 @@ jobs:
 
     - name: Set iOS extra xcode params
       if: matrix.platform == 'iOS' && contains(env.UPLOAD_TO, matrix.destination)
-      run: echo "EXTRA_XCODEBUILD=-sdk iphoneos26.0 ${{ env.APPLE_AUTH_PARAMS }}" >> $GITHUB_ENV
+      run: echo "EXTRA_XCODEBUILD=-sdk iphoneos26.1 ${{ env.APPLE_AUTH_PARAMS }}" >> $GITHUB_ENV
 
     - name: Set macOS extra xcode params
       if: matrix.platform == 'macOS' && contains(env.UPLOAD_TO, matrix.destination)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Set EXTRA_XCODEBUILD for iOS
         if: matrix.platform == 'iOS'
-        run: echo "EXTRA_XCODEBUILD=-sdk iphoneos26.0 ${{ env.APPLE_AUTH_PARAMS }}" >> $GITHUB_ENV
+        run: echo "EXTRA_XCODEBUILD=-sdk iphoneos26.1 ${{ env.APPLE_AUTH_PARAMS }}" >> $GITHUB_ENV
 
       - name: Set EXTRA_XCODEBUILD for macOS
         if: matrix.platform == 'macOS'


### PR DESCRIPTION
Fixes: #1447 

Due to changes in: https://github.com/actions/runner-images/issues/13570
The simplest solution is to upgrade to Xcode 26.1.1, otherwise we would need to download the runner image for each build, and that would take forever.