### PR TITLE
Fix macOS 26 cell backgrounds

### DIFF
--- a/Views/ViewModifiers/CellBackground.swift
+++ b/Views/ViewModifiers/CellBackground.swift
@@ -18,6 +18,8 @@ import SwiftUI
 enum CellBackground {
     #if os(macOS)
     private static let normal: Color = Color(nsColor: NSColor.controlBackgroundColor)
+    @available(macOS 26.0, *)
+    private static let normal26: Color = Color.secondaryBackground.opacity(0.12).mix(with: selected, by: 0.082)
     private static let selected: Color = Color(nsColor: NSColor.selectedControlColor)
     #else
     private static let normal: Color = .secondaryBackground
@@ -29,12 +31,26 @@ enum CellBackground {
         if isSelected {
             isHovering ? selected.opacity(0.75) : selected
         } else {
-            isHovering ? selected.opacity(0.5) : normal
+            if isHovering {
+                selected.opacity(0.5)
+            } else {
+                macOSCellBackground()
+            }
         }
         #else
         isHovering ? selected : normal
         #endif
     }
+    
+    #if os(macOS)
+    private static func macOSCellBackground() -> Color {
+        if #available(macOS 26, *) {
+            normal26
+        } else {
+            normal
+        }
+    }
+    #endif
     
     static let clipShapeRectangle = RoundedRectangle(cornerRadius: 12, style: .continuous)
     


### PR DESCRIPTION
Fixes: #1461 

## BEFORE
<img width="1405" height="876" alt="before_light" src="https://github.com/user-attachments/assets/bfb4e353-2c49-4e47-86ad-7861f111c3ab" />
<img width="1462" height="885" alt="before_dark" src="https://github.com/user-attachments/assets/e00170ba-0ef5-432a-adeb-192922b9556c" />


-----------
## AFTER
<img width="1405" height="876" alt="after_light" src="https://github.com/user-attachments/assets/8ba69620-a03b-43b0-b314-0d25ec6a5fb4" />
<img width="1405" height="876" alt="after_dark" src="https://github.com/user-attachments/assets/9f1c1753-2f03-4941-98ca-76d18fa26397" />


