### PR TITLE
Use full keyboard for hotspot port input on iPad

### DIFF
--- a/Views/BuildingBlocks/PortInput.swift
+++ b/Views/BuildingBlocks/PortInput.swift
@@ -35,12 +35,22 @@ struct PortInput: View {
     @Environment(\.controlActiveState) var controlActiveState
     #endif
     
+    #if os(iOS)
+    private var iOSKeyboardType: UIKeyboardType {
+        if Device.current == .iPad {
+            UIKeyboardType.numbersAndPunctuation
+        } else {
+            UIKeyboardType.numberPad
+        }
+    }
+    #endif
+    
     var body: some View {
         HStack {
             Text(LocalString.hotspot_settings_port_number)
             TextField("", text: $portNumber.stringValue)
             #if os(iOS)
-                .keyboardType(.numberPad)
+                .keyboardType(iOSKeyboardType)
                 .toolbar {
                     ToolbarItemGroup(placement: .keyboard) {
                         Spacer()


### PR DESCRIPTION
Fixes: #1457 

After lots of back and forth, the most reliable we can do is to use the full keyboard layout on iPad.
I tried different options:
https://stackoverflow.com/questions/61332009/how-can-i-show-done-button-on-the-decimal-pad-keyboard
some custom keyboard layout as well, but not worth the trouble.
Apple is not making this easy to be honest... (it should be a trivial thing really, numeric input + confirm...)

See it in action:

https://github.com/user-attachments/assets/f31b3345-ce09-464a-a786-627accb14bec




