### PR TITLE
Auto increment build number

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -65,6 +65,11 @@ jobs:
         sed -i '' '/in-app-payments/d' project.yml
         plutil -insert HIDE_DONATION -bool true Support/Info.plist
 
+    - name: Set BUILD NUMBER by date
+      run: |
+        export BUILD_NUMBER=$(date '+%Y%m%d.%H%M')
+        sed -i '' 's/CURRENT_PROJECT_VERSION: .*/CURRENT_PROJECT_VERSION: '$BUILD_NUMBER'/g' project.yml
+
     - name: Set VERSION from code
       shell: python
       run: |


### PR DESCRIPTION
Fixes: #1432

We wanted the build number to reflect the current date/time.
According to Apple's [doc on CURRENT_PROJECT_VERSION](https://developer.apple.com/documentation/xcode/build-settings-reference#Current-Project-Version), we can use a float.
Therefore the most readable format, I could come up with is:
``20260207.2323``

We also turning off Apple's auto-increment magic by setting the [manageAppVersionAndBuildNumber](https://stackoverflow.com/questions/68237292/xcode-manage-version-and-build-number-option) to false.