### PR TITLE
Do not mark ZimFile as not downloaded in case of an unexpected error

### DIFF
--- a/SwiftUI/Model/LibraryOperations.swift
+++ b/SwiftUI/Model/LibraryOperations.swift
@@ -93,8 +93,7 @@ ZIM file missing: \(zimFile.name, privacy: .public) |\
  \(downloadPath, privacy: .public)
 """)
             } catch {
-                zimFile.fileURLBookmark = nil
-                zimFile.isMissing = false
+                zimFile.isMissing = true
                 Log.LibraryOperations.notice("""
 ZIM file cannot be opened: \(zimFile.name, privacy: .public) |\ 
 \(downloadPath, privacy: .public) due to: \(error, privacy: .public)


### PR DESCRIPTION
Fixes: #1446 

Hopefully it will fix the original issue. 
I cannot achieve the same effect at the moment.
If I force the code to that case, then indeed the ZimFile(s) will disappear.
For this reason, I think we should apply this fix anyway.