### PR TITLE
fix: smooth tab switching with fade animations (#1479)

### DIFF
--- a/App/CompactViewController.swift
+++ b/App/CompactViewController.swift
@@ -136,11 +136,15 @@ private struct CompactViewWrapper: View {
     @EnvironmentObject private var navigation: NavigationViewModel
     
     var body: some View {
-        if case .loading = navigation.currentItem {
-            LoadingDataView()
-        } else if case let .tab(tabID) = navigation.currentItem {
-            CompactView(tabID: tabID)
+        Group {
+            if case .loading = navigation.currentItem {
+                LoadingDataView()
+            } else if case let .tab(tabID) = navigation.currentItem {
+                CompactView(tabID: tabID)
+                    .transition(.opacity)
+            }
         }
+        .animation(.easeInOut(duration: 0.2), value: navigation.currentItem)
     }
 }
 

--- a/Views/BrowserTab.swift
+++ b/Views/BrowserTab.swift
@@ -191,7 +191,7 @@ struct BrowserTab: View {
                                     .overlay {
                                         if case .webPage(let isLoading) = model.state, isLoading {
                                             LoadingProgressView()
-                                                .background(Color.background)
+                                                .allowsHitTesting(false)
                                         }
                                     }
 #if os(macOS)

--- a/Views/BuildingBlocks/WebView.swift
+++ b/Views/BuildingBlocks/WebView.swift
@@ -117,12 +117,14 @@ final class WebViewController: UIViewController {
         topSafeAreaConstraint = view.safeAreaLayoutGuide.topAnchor.constraint(equalTo: webView.topAnchor)
         topSafeAreaConstraint?.isActive = true
         layoutCancellable = layoutSubject
-            .debounce(for: .seconds(0.15), scheduler: RunLoop.main)
+            .debounce(for: .seconds(0.05), scheduler: RunLoop.main)
             .sink { [weak self] _ in
                 guard let view = self?.view,
                       let webView = self?.webView,
                       view.subviews.contains(webView) else { return }
-                webView.alpha = 1
+                UIView.animate(withDuration: 0.2) {
+                    webView.alpha = 1
+                }
                 guard self?.topSafeAreaConstraint?.isActive == true else { return }
                 self?.topSafeAreaConstraint?.isActive = false
                 self?.view.topAnchor.constraint(equalTo: webView.topAnchor).isActive = true


### PR DESCRIPTION
Fixes #1479

## Changes

### 1. Animated WebView fade-in ([WebView.swift](cci:7://file:///d:/kiwix-apple/Views/BuildingBlocks/WebView.swift:0:0-0:0))
- Changed the abrupt `alpha = 0 → 1` toggle to a smooth `UIView.animate(withDuration: 0.2)` fade-in
- Reduced layout debounce from 150ms to 50ms — just enough for layout stabilization without a visible blank

### 2. Translucent loading overlay ([BrowserTab.swift](cci:7://file:///d:/kiwix-apple/Views/BrowserTab.swift:0:0-0:0))
- Removed opaque `Color.background` from the `LoadingProgressView` overlay on iPad/macOS
- The loading spinner is now transparent so the underlying web content shows through during tab switch

### 3. Crossfade transition ([CompactViewController.swift](cci:7://file:///d:/kiwix-apple/App/CompactViewController.swift:0:0-0:0))
- Wrapped `CompactViewWrapper` body in a `Group` with `.animation(.easeInOut(duration: 0.2))`
- Added `.transition(.opacity)` to `CompactView` for a smooth crossfade when switching tabs on iPhone
