### PR TITLE
1498 Use a shared date formatter for parsing data

### DIFF
--- a/Model/Entities/ZimFileMetaData/ZimFileMetaData.mm
+++ b/Model/Entities/ZimFileMetaData/ZimFileMetaData.mm
@@ -137,10 +137,19 @@
     }
 }
 
++ (NSDateFormatter *) dateFormatter {
+    static NSDateFormatter *sharedFormatter = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sharedFormatter = [[NSDateFormatter alloc] init];
+        sharedFormatter.dateFormat = @"yyyy-MM-dd";
+        sharedFormatter.timeZone = [NSTimeZone timeZoneWithAbbreviation:@"UTC"];
+    });
+    return sharedFormatter;
+}
+
 - (NSDate *)getCreationDateFromBook:(kiwix::Book *)book {
-    NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
-    formatter.dateFormat = @"yyyy-MM-dd";
-    formatter.timeZone = [NSTimeZone timeZoneWithAbbreviation:@"UTC"];
+    NSDateFormatter *formatter = [ZimFileMetaData dateFormatter];
     return [formatter dateFromString:[NSString stringWithUTF8String:book->getDate().c_str()]];
 }
 


### PR DESCRIPTION
Related to: #1498 

We can re-use the date format instance, this way we can save around 0.2 sec out of the total 5 sec of parsing.