### PR TITLE
Fix button text tinting on macOS 26 in Light mode

### DIFF
--- a/Views/Library/Action.swift
+++ b/Views/Library/Action.swift
@@ -33,9 +33,14 @@ struct Action: View {
         AsyncButton(action: action, label: {
             HStack {
                 Spacer()
-                Text(title)
-                    .fontWeight(.medium)
-                    .foregroundColor(isDestructive ? .red : nil)
+                if isDestructive {
+                    Text(title)
+                        .fontWeight(.medium)
+                        .foregroundStyle(.red)
+                } else {
+                    Text(title)
+                        .fontWeight(.medium)
+                }
                 Spacer()
             }
         })


### PR DESCRIPTION
## Summary

Fixes #1496 — primary action buttons in `ZimFileDetail` (Open Main Page, Download) show incorrect text color on macOS 26 in Light mode when using `.borderedProminent` style.

## Problem

The `Action` view applied `.foregroundColor(nil)` to all non-destructive button text. On macOS 26, this explicit nil value interferes with `.borderedProminent`'s automatic white text styling in Light mode, causing the text to render with the default label color instead.

## Changes

- **`Action.swift`**: Only apply foreground styling for destructive actions (`.foregroundStyle(.red)`). Non-destructive buttons now inherit their text color from the button style, allowing `.borderedProminent` to correctly set white text on the blue background.
- Migrates from deprecated `foregroundColor` to `foregroundStyle`.

## Notes

Dark mode is unaffected (as noted in the issue). This is a macOS-only fix — the `.borderedProminent` style is only applied on macOS views.