### PR TITLE
Update to libkiwix-14.2.0

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -4,7 +4,7 @@ brew "curl"
 
 at_exit do
     system "pre-commit install"
-    system "curl -L -o - https://download.kiwix.org/release/libkiwix/libkiwix_xcframework-14.1.1-1.tar.gz | tar -x --strip-components 2"
+    system "curl -L -o - https://download.kiwix.org/release/libkiwix/libkiwix_xcframework-14.2.0.tar.gz | tar -x --strip-components 2"
     # Copy Clang module map to xcframework for Swift C++ Interoperability
     system "cp Support/CoreKiwix.modulemap CoreKiwix.xcframework/ios-arm64/Headers/module.modulemap"
     system "cp Support/CoreKiwix.modulemap CoreKiwix.xcframework/ios-arm64_x86_64-simulator/Headers/module.modulemap"


### PR DESCRIPTION
Fixes: #1498 

Greatly reduces the XML parsing time !

Measured on macOS:

## Before 4.792 sec:
```
Test Case '-[UnitTests.ParsePerformanceTest testPerformanceExample]' measured
[Time, seconds] average: 4.792, 
relative standard deviation: 0.570%,
values: [4.866618, 4.810578, 4.791723, 4.778064, 4.771585, 4.786351, 4.788805, 4.785569, 4.770599, 4.772311]
```

## After 1.959 sec:
```
Test Case '-[UnitTests.ParsePerformanceTest testPerformanceExample]' measured
[Time, seconds] average: 1.959, 
relative standard deviation: 1.592%, 
values: [2.006691, 1.953365, 1.944594, 1.958384, 1.939742, 1.947786, 1.933075, 1.935462, 1.937291, 2.029815]
```