### PR TITLE
Swift 6 update to stripe-apple 25.7.2, fix payment sheet

### DIFF
--- a/Model/Payment.swift
+++ b/Model/Payment.swift
@@ -202,7 +202,7 @@ struct Payment {
                 let paymentServer = StripeKiwix(endPoint: Self.kiwixPaymentServer)
                 do {
                     let publicKey = try await paymentServer.publishableKey()
-                    StripeAPI.defaultPublishableKey = publicKey
+                    StripeAPI.setDefault(publishableKey: publicKey)
                 } catch let serverError {
                     Self.finalResult = .error
                     resultHandler(.init(status: .failure, errors: [serverError]))
@@ -216,7 +216,7 @@ struct Payment {
                                                    returnURLPath: nil,
                                                    usingClientSecretProvider: { @Sendable in
                     await StripeKiwix.clientSecretForPayment(endPoint: endPoint, selectedAmount: selectedAmount)
-                })
+                }, withAPI: StripeAsyncAPI())
                 // calling any UI refreshing state / subject from here
                 // will block the UI in the payment state forever
                 // therefore it's defered via static finalResult

--- a/Views/Payment/DonationViewModifier.swift
+++ b/Views/Payment/DonationViewModifier.swift
@@ -44,11 +44,11 @@ struct DonationViewModifier: ViewModifier {
                     donationPopUpState = .selection
                     return
                 case .some(let finalResult):
-                    Task {
+                    Task.detached(priority: .utility) {
                         // we need to close the sheet in order to dismiss ApplePay,
                         // and we need to re-open it again with a delay to show thank you state
                         // Swift UI cannot yet handle multiple sheets
-                        try? await Task.sleep(for: .milliseconds(100))
+                        try? await Task.sleep(for: .milliseconds(1000))
                         await MainActor.run {
                             switch finalResult {
                             case .thankYou:

--- a/Views/Payment/PaymentSummary.swift
+++ b/Views/Payment/PaymentSummary.swift
@@ -24,6 +24,7 @@ struct PaymentSummary: View {
     private let selectedAmount: SelectedAmount
     private let payment: Payment
     private let onComplete: @MainActor () -> Void
+    @State private var paymentDetermined: Bool = false
     @State private var paymentButtonLabel: PayWithApplePayButtonLabel?
 
     init(selectedAmount: SelectedAmount,
@@ -46,28 +47,33 @@ struct PaymentSummary: View {
                     .padding()
             }
             Text(selectedAmount.value.formatted(.currency(code: selectedAmount.currency))).font(.title).bold()
-            if let paymentButtonLabel {
-                PayWithApplePayButton(
-                    paymentButtonLabel,
-                    request: payment.donationRequest(for: selectedAmount),
-                    onPaymentAuthorizationChange: { phase in
-                        payment.onPaymentAuthPhase(selectedAmount: selectedAmount,
-                                                   phase: phase)
-                    },
-                    onMerchantSessionRequested: payment.onMerchantSessionUpdate
-                )
-                .frame(width: 186, height: 44)
-                .padding()
+            if paymentDetermined {
+                if let paymentButtonLabel {
+                    PayWithApplePayButton(
+                        paymentButtonLabel,
+                        request: payment.donationRequest(for: selectedAmount),
+                        onPaymentAuthorizationChange: { phase in
+                            payment.onPaymentAuthPhase(selectedAmount: selectedAmount,
+                                                       phase: phase)
+                        },
+                        onMerchantSessionRequested: payment.onMerchantSessionUpdate
+                    )
+                    .frame(width: 186, height: 44)
+                    .padding()
+                } else {
+                    Text(LocalString.payment_support_fallback_message)
+                        .foregroundStyle(.red)
+                        .font(.callout)
+                }
             } else {
-                Text(LocalString.payment_support_fallback_message)
-                    .foregroundStyle(.red)
-                    .font(.callout)
+                LoadingProgressView()
             }
         }.onReceive(payment.completeSubject) {
             onComplete()
         }
         .task {
             paymentButtonLabel = await Payment.paymentButtonTypeAsync()
+            paymentDetermined = true
         }
     }
 }

--- a/project.yml
+++ b/project.yml
@@ -50,7 +50,7 @@ packages:
     majorVersion: 8.2.0
   StripeApplePay:
     url: https://github.com/CodeLikeW/stripe-apple-pay
-    majorVersion: 24.23.0
+    majorVersion: 25.7.2
   SwiftSystem:
     url: https://github.com/apple/swift-system
     revision: b083113aef646d9d35403ca17e9789b750e42d1d


### PR DESCRIPTION
Fixes: #1500 

On the Kiwix side the changes are rather small:
- update the dependency version
- Fixed the loading state of the payment
- increased the delay of the displaying the Thank you state. On my tests, when I do a payment, in the meantime my phone is receiving a system notification from the bank, which slows things down. It's better to display the Thank you page a bit later, than not displaying it at all.
- a lot more changes went into the [stripe-core](https://github.com/CodeLikeW/stripe-core/compare/24.23.0...25.7.2) and the [stripe-apple-pay](https://github.com/CodeLikeW/stripe-apple-pay/compare/24.23.0...25.7.2) dependencies.
- both dependencies are up to date with the latest Stripe upstream changes, and fully Swift 6 compatible

I did several real payment testing on macOS and iOS as well.