### PR TITLE
Fix search bar in compact mode

### DIFF
--- a/App/CompactViewController.swift
+++ b/App/CompactViewController.swift
@@ -24,6 +24,13 @@ import UIKit
 import CoreData
 import Defaults
 
+/// Bridge between UIKit and SwiftUI search state and dismiss
+private final class SearchUpdate: ObservableObject {
+    @Published var isSearching: Bool = false
+    var dismiss: (() -> Void)?
+}
+
+// iPhone portrait only
 final class CompactViewController: UIHostingController<AnyView>, UISearchControllerDelegate, UISearchResultsUpdating {
     private let searchViewModel: SearchViewModel
     private let searchController: UISearchController
@@ -34,14 +41,17 @@ final class CompactViewController: UIHostingController<AnyView>, UISearchControl
     private var rightNavItem: UIBarButtonItem?
     private let navigation: NavigationViewModel
     private var navigationItemObserver: AnyCancellable?
+    // bridge down to Content's SwiftUI state
+    private var searchUpdate = SearchUpdate()
 
     init(navigation: NavigationViewModel) {
         self.navigation = navigation
         searchViewModel = SearchViewModel.shared
         let searchResult = SearchResults().environmentObject(searchViewModel)
         searchController = UISearchController(searchResultsController: UIHostingController(rootView: searchResult))
-        super.init(rootView: AnyView(CompactViewWrapper()))
+        super.init(rootView: AnyView(CompactViewWrapper().environmentObject(searchUpdate)))
         searchController.searchResultsUpdater = self
+        searchUpdate.dismiss = { [weak self] in self?.onSearchCancelled() }
     }
 
     @MainActor required dynamic init?(coder aDecoder: NSCoder) {
@@ -105,27 +115,18 @@ final class CompactViewController: UIHostingController<AnyView>, UISearchControl
 
     func willPresentSearchController(_ searchController: UISearchController) {
         navigationController?.setToolbarHidden(true, animated: true)
-        trailingNavItemGroups = navigationItem.trailingItemGroups
-        navigationItem.setRightBarButton(
-            UIBarButtonItem(
-                title: LocalString.common_button_cancel,
-                style: .done,
-                target: self,
-                action: #selector(onSearchCancelled)
-            ),
-            animated: true
-        )
+        searchUpdate.isSearching = true
     }
-    @objc func onSearchCancelled() {
+    
+    func onSearchCancelled() {
         searchController.isActive = false
-        navigationItem.setRightBarButtonItems(nil, animated: false)
-        navigationItem.trailingItemGroups = trailingNavItemGroups
+        searchUpdate.isSearching = false
     }
 
     func willDismissSearchController(_ searchController: UISearchController) {
         navigationController?.setToolbarHidden(false, animated: true)
         searchViewModel.searchText = ""
-        navigationItem.trailingItemGroups = trailingNavItemGroups
+        searchUpdate.isSearching = false
     }
 
     func updateSearchResults(for searchController: UISearchController) {
@@ -135,6 +136,7 @@ final class CompactViewController: UIHostingController<AnyView>, UISearchControl
 
 private struct CompactViewWrapper: View {
     @EnvironmentObject private var navigation: NavigationViewModel
+    @EnvironmentObject var searchUpdate: SearchUpdate
 
     var body: some View {
         if case .loading = navigation.currentItem {
@@ -190,9 +192,7 @@ private struct CompactView: View {
             showLibrary: {
                 if presentedSheet == nil {
                     presentedSheet = .library(downloads: false)
-                } else {
-                    // there's a sheet already presented by the user
-                    // do nothing
+                } else { // there's a sheet already presented by the user, do nothing
                 }
             },
             showSettings: {
@@ -273,9 +273,7 @@ private struct CompactView: View {
             }
         }
         .onReceive(hotspotShareURL) { notification in
-            guard let url = notification.userInfo?["url"] as? URL else {
-                return
-            }
+            guard let url = notification.userInfo?["url"] as? URL else { return }
             presentedSheet = .hotspotShare(url: url)
         }
         .onReceive(navigateToHotspotSettings) { _ in
@@ -291,6 +289,8 @@ private struct Content<LaunchModel>: View where LaunchModel: LaunchProtocol {
     let showSettings: () -> Void
     @ObservedObject var model: LaunchModel
     
+    // comes from all the way from CompactViewController's UIKit search bar
+    @EnvironmentObject private var searchUpdate: SearchUpdate
     @Environment(\.scenePhase) private var scenePhase
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @EnvironmentObject private var library: LibraryViewModel
@@ -351,14 +351,24 @@ private struct Content<LaunchModel>: View where LaunchModel: LaunchProtocol {
             }
         }
         .toolbar {
-            ToolbarItemGroup(placement: .primaryAction) {
-                if !Brand.hideFindInPage {
-                    ContentSearchButton(browser: browser)
+            if searchUpdate.isSearching {
+                ToolbarItem(placement: .primaryAction) {
+                    Button { [weak searchUpdate] in
+                        searchUpdate?.dismiss?()
+                    } label: {
+                        Text(LocalString.common_button_cancel)
+                    }
                 }
-                Button {
-                    showSettings()
-                } label: {
-                    Label(LocalString.common_tab_menu_settings, systemImage: "gear")
+            } else {
+                ToolbarItemGroup(placement: .primaryAction) {
+                    if !Brand.hideFindInPage {
+                        ContentSearchButton(browser: browser)
+                    }
+                    Button {
+                        showSettings()
+                    } label: {
+                        Label(LocalString.common_tab_menu_settings, systemImage: "gear")
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes: #1510 

Well, we still have some left overs of UIKit on the iPhone compact / landscape mode.
This caused us some headaches with the search bar state.

So we had the toolbar items controlled from 2 places:
- top down from UIKit's search view controller, trying to replace the items with the cancel button, when the search is active, and restoring those items, when the search is over 
- from the content view in SwiftUI bottom up, setting up other items into the toolbar

The above worked for most cases, but when we background / foreground the app, what really happens is that the UIKit is not refreshing, while the SwiftUI content does refresh, and it will set up the toolbar items as it suppose to, but we are in search mode, and the SwiftUI view has no clue about that.

# Short term solution (this PR):
- jump through some hoops, and do a bridging between UIKit and SwiftUI, and have a single source of state
- set up the cancel button of the search bar from SwiftUI, this way we have the same lifecycle for all toolbar items (they are refreshed at the same time).
- the only difference is that we cannot have the cancel button in the "accent" / blue color, but I think it was too "aggressive" anyway, so if you ask me, it's better this way:

## BEFORE

https://github.com/user-attachments/assets/d47590f2-4833-4931-9f04-da463380cdf2


## AFTER

https://github.com/user-attachments/assets/812ff8ff-eea1-4c89-9611-2cd9f3b1be7a

---------------------
# Possible long term solution:
- is to remove the older UIKit solution altogether
- this will result in less convoluted code
- the down-side is that the search field cannot be displayed in the same place. SwiftUI will place it below the toolbar, at least that is what I've found so far:
https://developer.apple.com/documentation/swiftui/searchfieldplacement
- overall Apple's recommendation is to put the search bar at the bottom of that screen... this brings in even more discussion, so let's leave that for later.



