### PR TITLE
Fix macOS autolayout including video fullscreen as well

### DIFF
--- a/Views/BuildingBlocks/WebView.swift
+++ b/Views/BuildingBlocks/WebView.swift
@@ -22,44 +22,90 @@ import Defaults
 #if os(macOS)
 struct WebView: NSViewRepresentable {
     @ObservedObject var browser: BrowserViewModel
-
+    
     func makeNSView(context: Context) -> NSView {
         let nsView = NSView()
         let webView = browser.webView
-        // auto-layout is not working
-        // when the video is paused in full screen
+        enableAutoLayout(nsView: nsView, webView: webView)
+        return nsView
+    }
+    
+    func updateNSView(_ nsView: NSView, context: Context) {}
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(view: self,
+                    onChangingFullscreen: { (enters: Bool, webView: WKWebView) in
+            guard let nsView = webView.superview else { return }
+            if enters {
+                // auto-layout is not working
+                // when the video is paused in full screen
+                disableAutoLayout(nsView: nsView, webView: webView)
+            } else {
+                enableAutoLayout(nsView: nsView, webView: webView)
+            }
+        })
+    }
+    
+    @MainActor
+    private func enableAutoLayout(nsView: NSView, webView: WKWebView) {
+        webView.removeFromSuperview()
+        webView.translatesAutoresizingMaskIntoConstraints = false
+        nsView.addSubview(webView)
+        
+        NSLayoutConstraint.activate([
+            webView.leadingAnchor.constraint(equalTo: nsView.safeAreaLayoutGuide.leadingAnchor),
+            webView.trailingAnchor.constraint(equalTo: nsView.safeAreaLayoutGuide.trailingAnchor),
+            webView.topAnchor.constraint(equalTo: nsView.safeAreaLayoutGuide.topAnchor),
+            webView.bottomAnchor.constraint(equalTo: nsView.safeAreaLayoutGuide.bottomAnchor)
+        ])
+    }
+    
+    @MainActor
+    private func disableAutoLayout(nsView: NSView, webView: WKWebView) {
+        webView.removeFromSuperview()
         webView.translatesAutoresizingMaskIntoConstraints = true
         webView.autoresizingMask = [.width, .height]
         nsView.addSubview(webView)
-        return nsView
-    }
-
-    func updateNSView(_ nsView: NSView, context: Context) {
-        // without this, after closing video full screen
-        // a newly opened webview's frame is wrongly sized
-        browser.webView.frame = nsView.bounds
-    }
-
-    func makeCoordinator() -> Coordinator {
-        Coordinator(view: self)
     }
 
     final class Coordinator {
         private let pageZoomObserver: Defaults.Observation
+        private let fullScreenObserver: NSKeyValueObservation
 
         @MainActor
-        init(view: WebView) {
+        init(
+            view: WebView,
+            onChangingFullscreen: @escaping @Sendable @MainActor (_ enters: Bool, _ webView: WKWebView) -> Void
+        ) {
             let browser = view.browser
             pageZoomObserver = Defaults.observe(.webViewPageZoom) { [weak browser] change in
                 browser?.webView.pageZoom = change.newValue
+            }
+            fullScreenObserver = view.browser.webView.observe(\.fullscreenState, options: [.new]) { webView, _ in
+                Task { @MainActor in
+                    switch webView.fullscreenState {
+                    case .enteringFullscreen:
+                        onChangingFullscreen(true, webView)
+                    case .inFullscreen:
+                        break
+                    case .exitingFullscreen:
+                        onChangingFullscreen(false, webView)
+                    case .notInFullscreen:
+                        break
+                    @unknown default:
+                        break
+                    }
+                }
             }
         }
         
         deinit {
             pageZoomObserver.invalidate()
+            fullScreenObserver.invalidate()
         }
     }
 }
+
 #elseif os(iOS)
 struct WebView: UIViewControllerRepresentable {
     @ObservedObject var browser: BrowserViewModel


### PR DESCRIPTION
Fixes: #1497 

## Solution:
Catch the moment when we switch to html fullscreen mode and back, as described here:
https://wwdcnotes.com/documentation/wwdcnotes/wwdc22-10049-whats-new-in-wkwebview/#Fullscreen-API

This way we can toggle between auto-layout, which is fixing the margin problem described in the issue, and the full width+height layout, that we need for our full screen video to keep working.

# BEFORE:

https://github.com/user-attachments/assets/af51c24c-d6d5-4637-868a-23c7b295f664


# AFTER:

https://github.com/user-attachments/assets/3e4fd22f-c784-4e97-b2b7-ab732ed6ac1e


