### PR TITLE
[maps] Fix map not displayed full screen on initial load

### DIFF
--- a/ViewModel/BrowserViewModel.swift
+++ b/ViewModel/BrowserViewModel.swift
@@ -513,7 +513,7 @@ import CoreKiwix
         webView.adjustTextSize()
 #else
         Task { await persistState() }
-        let js = """
+        let mapResizeScript = """
             (function() {
                 var el = document.getElementById('map');
                 var canvas = el && el.querySelector('canvas');
@@ -522,7 +522,7 @@ import CoreKiwix
                 setTimeout(function() { el.style.removeProperty('height'); }, 200);
             })();
             """
-        webView.evaluateJavaScript(js, completionHandler: nil)
+        webView.evaluateJavaScript(mapResizeScript, completionHandler: nil)
 #endif
     }
 


### PR DESCRIPTION
## Problem                                                                      
  Fixes #1521     
                                                                                            
  On macOS, MapLibre GL JS initialises its WebGL canvas while the WKWebView frame is still settling, resulting in a canvas smaller than the map container (~196pt instead of 500pt). MapLibre's ResizeObserver skips its first callback by design, so when the WKWebView grows to its final size the canvas is never corrected.                                          
                                                  
  ## Root cause
  - WKWebView frame transitions through an intermediate size during SwiftUI layout
  - MapLibre reads _`clientHeight`_ at that intermediate size and initialises the canvas accordingly                                                                               
  - The 196pt→500pt growth triggers the ResizeObserver skip-first callback, consuming it    
  - No further size change occurs, leaving the canvas at the wrong size                     
                                                                                            
  ## Fix                                                                                    
  After _`didFinish`_, if the map canvas is shorter than its container, bump the container height by 1pt and restore it after 200ms. This fires a second ResizeObserver callback (the one that actually calls _`map.resize()`_) at the correct final height.                   
                                                                         
  ## Testing                                                                                
  Tested with _`maps_en_monaco_2026-03.zim`_ on macOS — map now displays full screen on initial load without requiring window resize.


https://github.com/user-attachments/assets/6769714e-f0ec-40ea-9919-b73312651788

