### PR TITLE
Update diagnostic state to run in background

### DIFF
--- a/Views/Settings/Diagnostics/DiagnosticsModel.swift
+++ b/Views/Settings/Diagnostics/DiagnosticsModel.swift
@@ -114,12 +114,10 @@ final class DiagnosticsModel: ObservableObject {
     private var cancellable: AnyCancellable?
     
     func cancel() {
-        Task { @MainActor in
-            cancellable?.cancel()
-            integrityModel.reset()
-            items = Const.defaultItems
-            integrityModel = ZimIntegrityModel()
-        }
+        cancellable?.cancel()
+        integrityModel.reset()
+        items = Const.defaultItems
+        integrityModel = ZimIntegrityModel()
     }
     
     func start(using zimFiles: [ZimFile]) async -> [String] {
@@ -142,7 +140,6 @@ final class DiagnosticsModel: ObservableObject {
         return entries
     }
     
-    @MainActor
     private func integrityCheckProgress(title: String) {
         items = items.map { item in
             if item.id == .integrityCheck {
@@ -156,7 +153,6 @@ final class DiagnosticsModel: ObservableObject {
         }
     }
     
-    @MainActor
     private func updateItemBy(id: DiagnosticItem.Identifier, status: DiagnosticItem.Status) {
         items = items.map { item in
             if item.id == id {
@@ -170,26 +166,22 @@ final class DiagnosticsModel: ObservableObject {
     }
     
     private func didReceive(checkInfos: [ZimIntegrityModel.Info]) {
-        Task { @MainActor [weak self] in
-            guard var items = self?.items else { return }
-            if let integrityIndex = items.firstIndex(where: { $0.id == .integrityCheck }) {
-                items.remove(at: integrityIndex)
+        if let integrityIndex = items.firstIndex(where: { $0.id == .integrityCheck }) {
+            items.remove(at: integrityIndex)
+        }
+        for check in checkInfos {
+            if let index = items.firstIndex(where: { $0.id == .integrityZIM(check.id) }) {
+                var item: DiagnosticItem = items[index]
+                item.status = .from(checkState: check.state)
+                items[index] = item
+            } else {
+                let title = LocalString.zim_file_integrity_check_in_progress(withArgs: check.zimFile.name)
+                let newItem = DiagnosticItem(id: .integrityZIM(check.id),
+                                             title: title,
+                                             status: .from(checkState: check.state))
+                let insertIndex: Int = items.firstIndex(where: { $0.id == .applicationLogs }) ?? 0
+                items.insert(newItem, at: insertIndex)
             }
-            for check in checkInfos {
-                if let index = items.firstIndex(where: { $0.id == .integrityZIM(check.id) }) {
-                    var item: DiagnosticItem = items[index]
-                    item.status = .from(checkState: check.state)
-                    items[index] = item
-                } else {
-                    let title = LocalString.zim_file_integrity_check_in_progress(withArgs: check.zimFile.name)
-                    let newItem = DiagnosticItem(id: .integrityZIM(check.id),
-                                                 title: title,
-                                                 status: .from(checkState: check.state))
-                    let insertIndex: Int = items.firstIndex(where: { $0.id == .applicationLogs }) ?? 0
-                    items.insert(newItem, at: insertIndex)
-                }
-            }
-            self?.items = items
         }
     }
 }

--- a/Views/Settings/Diagnostics/DiagnosticsView.swift
+++ b/Views/Settings/Diagnostics/DiagnosticsView.swift
@@ -15,20 +15,18 @@
 
 import SwiftUI
 import CoreData
+import Combine
 
 /// NOTE: This view is not translated on purpose.
 /// We want to make sure users only send us reports in English
 @MainActor
 struct DiagnosticsView: View {
-    
+   
     @FetchRequest(
         sortDescriptors: [NSSortDescriptor(keyPath: \ZimFile.size, ascending: false)],
         predicate: ZimFile.integrityCheckablePredicate()
     ) private var zimFiles: FetchedResults<ZimFile>
-    @State private var logs: [String] = []
-    @State private var isRunning: Bool = false
-    @State private var integrityTask: Task<Void, Error>?
-    @MainActor @ObservedObject private var model = DiagnosticsModel()
+    @ObservedObject var model = GlobalDiagnosticsModel.shared
     
     private enum Const {
         #if os(iOS)
@@ -44,75 +42,63 @@ struct DiagnosticsView: View {
             diagnosticItems
             Spacer(minLength: Const.verticalSpace)
             HStack(alignment: .firstTextBaseline, spacing: 24) {
-                if !logs.isEmpty {
-                    emailButton
+                switch model.state {
+                case .initial:
 #if os(macOS)
-                    saveButton
-#else
-                    shareButton
+                    runButton(again: false)
 #endif
-                } else {
-                    if isRunning {
-                        VStack(alignment: .center) {
-                            ProgressView()
-                                .progressViewStyle(.circular)
-                            #if os(macOS)
-                                .scaleEffect(0.5)
-                                .padding(-8)
-                            #endif
-                            
-                            Text("Checking...")
-                                .foregroundStyle(.secondary)
-                            
-                            #if os(macOS)
-                            cancelButton
-                            #endif
-                        }
-                        .padding(.vertical)
-                    } else {
+                case .running:
+                    VStack(alignment: .center) {
+                        ProgressView()
+                            .progressViewStyle(.circular)
                         #if os(macOS)
-                        runButton
+                            .scaleEffect(0.5)
+                            .padding(-8)
+                        #endif
+                        
+                        Text("Checking...")
+                            .foregroundStyle(.secondary)
+                        
+                        #if os(macOS)
+                        cancelButton
                         #endif
                     }
+                    .padding(.vertical)
+                case let .complete(logs):
+                    emailButton(logs: logs)
+#if os(macOS)
+                    saveButton(logs: logs)
+                    runButton(again: true)
+#else
+                    shareButton(logs: logs)
+#endif
                 }
             }
             Spacer(minLength: Const.verticalSpace)
         }
         .frame(maxWidth: 500)
         .navigationTitle("Diagnostic Items")
-        #if os(iOS)
+#if os(iOS)
         .toolbar {
-            if logs.isEmpty {
-                if !isRunning {
-                    ToolbarItem(placement: .topBarTrailing) {
-                        runButton
-                            .padding(.horizontal)
-                    }
-                } else {
-                    ToolbarItem(placement: .topBarTrailing) {
-                       cancelButton
-                            .padding(.horizontal)
-                    }
+            ToolbarItem(placement: .topBarTrailing) {
+                switch model.state {
+                case .initial:
+                    runButton(again: false)
+                        .padding(.horizontal)
+                case .complete:
+                    runButton(again: true)
+                        .padding(.horizontal)
+                case .running:
+                    cancelButton
+                        .padding(.horizontal)
                 }
             }
         }
-        #endif
-        .onDisappear(perform: {
-           cancel()
-        })
-#if os(iOS)
         .navigationBarTitleDisplayMode(.inline)
         .padding(.horizontal, 40)
 #else
         .tabItem { Label("Diagnostics", systemImage: "exclamationmark.bubble") }
 #endif
-    }
-    
-    private func cancel() {
-        model.cancel()
-        integrityTask?.cancel()
-        logs = []
-        isRunning = false
     }
     
     @ViewBuilder
@@ -130,43 +116,63 @@ struct DiagnosticsView: View {
             .listRowSpacing(-10)
             #endif
             .listStyle(.plain)
-            .onChange(of: model.items) {
-                if let firstInitial = model.items.first(where: { item in
-                    item.status == .initial
-                }) {
-                    proxy.scrollTo(firstInitial.id)
-                }
+            .onChange(of: model.state) {
+                adjustScroll(using: proxy)
             }
+            .onChange(of: model.items) {
+                scrollToFirstInitialItem(using: proxy)
+            }
+            .task {
+                adjustScroll(using: proxy)
+            }
+        }
+    }
+    
+    private func adjustScroll(using proxy: ScrollViewProxy) {
+        switch model.state {
+        case .initial, .running:
+            scrollToFirstInitialItem(using: proxy)
+        case .complete:
+            scrollToLastItem(using: proxy)
+        }
+    }
+    
+    private func scrollToFirstInitialItem(using proxy: ScrollViewProxy) {
+        if let firstInitial = model.items.first(where: { item in
+            item.status == .initial
+        }) {
+            proxy.scrollTo(firstInitial.id)
+        }
+    }
+    
+    private func scrollToLastItem(using proxy: ScrollViewProxy) {
+        if let lastItem = model.items.last {
+            proxy.scrollTo(lastItem.id)
         }
     }
     
     @ViewBuilder
     var cancelButton: some View {
         Button(LocalString.common_button_cancel, role: .destructive) {
-            cancel()
+            model.cancel()
         }
     }
     
     @ViewBuilder
-    var runButton: some View {
+    func runButton(again: Bool) -> some View {
         AsyncButton {
             withAnimation {
-                isRunning = true
-                integrityTask = Task { @MainActor in
-                    let collectedLogs = await model.start(using: zimFiles.reversed())
-                    if !Task.isCancelled {
-                        logs = collectedLogs
-                        isRunning = false
-                    }
-                }
+                model.start(using: zimFiles.reversed())
             }
         } label: {
-            #if os(macOS)
-            Label("Run check", systemImage: "exclamationmark.bubble")
-                .symbolEffect(.bounce, value: isRunning)
-            #else
-            Text("Run check")
-            #endif
+#if os(macOS)
+            let title: String = again ? "Run check again" : "Run check"
+            Label(title, systemImage: "exclamationmark.bubble")
+                .symbolEffect(.bounce, value: model.state == .running)
+#else
+            let title: String = again ? "Run again" : "Run check"
+            Text(title)
+#endif
         }
 #if os(iOS)
         .buttonStyle(.borderless)
@@ -174,14 +180,14 @@ struct DiagnosticsView: View {
     }
     
     @ViewBuilder
-    var emailButton: some View {
+    func emailButton(logs: [String]) -> some View {
         AsyncButton {
             let emailLogs = logs.joined(separator: Email.separator())
             let email = Email(logs: emailLogs)
             email.create()
         } label: {
             Label("Email", systemImage: "paperplane")
-                .symbolEffect(.bounce, value: isRunning)
+                .symbolEffect(.bounce, value: model.state == .running)
         }
 #if os(iOS)
         .buttonStyle(.borderless)
@@ -190,7 +196,7 @@ struct DiagnosticsView: View {
     
 #if os(macOS)
     @ViewBuilder
-    var saveButton: some View {
+    func saveButton(logs: [String]) -> some View {
         AsyncButton {
             let fileLogs = logs.joined(separator: "\n")
             guard let data = fileLogs.data(using: .utf8) else { return }
@@ -203,14 +209,14 @@ struct DiagnosticsView: View {
             }
         } label: {
             Label("Save log file", systemImage: "square.and.arrow.down")
-                .symbolEffect(.bounce, value: isRunning)
+                .symbolEffect(.bounce, value: model.state == .running)
         }
     }
 #endif
     
 #if os(iOS)
     @ViewBuilder
-    var shareButton: some View {
+    func shareButton(logs: [String]) -> some View {
         AsyncButton {
             let fileLogs = logs.joined(separator: "\n")
             guard let data = fileLogs.data(using: .utf8) else { return }
@@ -222,7 +228,7 @@ struct DiagnosticsView: View {
             NotificationCenter.exportFileData(exportData)
         } label: {
             Label("Share", systemImage: "square.and.arrow.up")
-                .symbolEffect(.bounce, value: isRunning)
+                .symbolEffect(.bounce, value: model.state == .running)
         }
         .buttonStyle(.borderless)
     }

--- a/Views/Settings/Diagnostics/GlobalDiagnosticsModel.swift
+++ b/Views/Settings/Diagnostics/GlobalDiagnosticsModel.swift
@@ -1,0 +1,98 @@
+// This file is part of Kiwix for iOS & macOS.
+//
+// Kiwix is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// any later version.
+//
+// Kiwix is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kiwix; If not, see https://www.gnu.org/licenses/.
+
+import Foundation
+import SwiftUI
+import Combine
+
+enum DiagState: Equatable {
+    case initial
+    case running
+    case complete(logs: [String])
+}
+
+@MainActor
+final class GlobalDiagnosticsModel: ObservableObject {
+    @Published var state: DiagState
+    @Published var items: [DiagnosticItem]
+    private var model: DiagnosticsModel
+    private var task: Task<Void, Error>?
+    private var cancellable: AnyCancellable?
+    
+    @MainActor
+    static let shared = GlobalDiagnosticsModel()
+    
+    private init() {
+        (model, state) = Self.resetState()
+        items = model.items
+    }
+    
+    func start(using zimFiles: [ZimFile]) {
+        switch state {
+        case .running:
+            // cannot start if it's already running
+            return
+        case .complete:
+            // reset all and start
+            cancelTask()
+            (model, state) = Self.resetState()
+            items = model.items
+        case .initial:
+            break
+        }
+        self.task = Task { @MainActor [weak self]  in
+            self?.cancellable =  self?.model.$items.sink { [weak self] newItems in
+                if !Task.isCancelled {
+                    if self?.state != .running {
+                        self?.state = .running
+                    }
+                    self?.items = newItems
+                }
+            }
+            if let model = self?.model {
+                if !Task.isCancelled {
+                    let logs = await model.start(using: zimFiles)
+                    if !Task.isCancelled {
+                        self?.state = .complete(logs: logs)
+                    }
+                }
+            }
+        }
+    }
+    
+    func cancel() {
+        switch state {
+        case .complete, .initial:
+            // cannot cancel these states
+            return
+        case .running:
+            cancelTask()
+            (model, state) = Self.resetState()
+            items = model.items
+        }
+    }
+    
+    private static func resetState() -> (DiagnosticsModel, DiagState) {
+        let model = DiagnosticsModel()
+        return (model, DiagState.initial)
+    }
+    
+    private func cancelTask() {
+        task?.cancel()
+        task = nil
+        cancellable?.cancel()
+        cancellable = nil
+    }
+}


### PR DESCRIPTION
Fixes: #1522 
Fixes: #1519 

I had to add a "run again" state as well, since we can come back to the same view, that has finished, and there should be a way to restart it in that case as well.

## iPad:

https://github.com/user-attachments/assets/f23c3931-6347-4aa5-943c-9e22f5db2727

## iPhone:

https://github.com/user-attachments/assets/531e16dc-f2ee-41b8-94f9-e774c41418cb


## macOS:

https://github.com/user-attachments/assets/215774e5-b501-4e95-aa62-62536f3b4f6c

