### PR TITLE
Fix macOS Apple Pay compatibility

### DIFF
--- a/App/RootView_macOS.swift
+++ b/App/RootView_macOS.swift
@@ -15,7 +15,6 @@
 
 #if os(macOS)
 import SwiftUI
-import PassKit
 
 struct RootView: View {
     @Environment(\.openWindow) var openWindow
@@ -23,7 +22,7 @@ struct RootView: View {
     @StateObject private var navigation = NavigationViewModel()
     @State private var currentNavItem: MenuItem?
     @StateObject private var windowTracker = WindowTracker()
-    @State private var paymentButtonLabel: PayWithApplePayButtonLabel?
+    @State private var paymentButtonLabel: Payment.ButtonLabelType?
     var isSearchFocused: FocusState<Bool>.Binding
     @StateObject private var selection = SelectedZimFileViewModel()
     // Open file alerts

--- a/Model/Payment.swift
+++ b/Model/Payment.swift
@@ -122,23 +122,22 @@ struct Payment {
     /// - Returns: Setup button if no cards added yet,
     /// nil if Apple Pay is not supported
     /// or donation button, if all is OK
-    static private func paymentButtonType() -> ApplePaymentLabelType? {
+    static private func paymentButtonType() -> ButtonLabelType? {
         // only kiwix app is supporting donations atm.
         guard case .kiwix = AppType.current else { return nil }
-        
         if PKPaymentAuthorizationController.canMakePayments() {
-            return ApplePaymentLabelType.donate
+            return ButtonLabelType.donate
         }
         if PKPaymentAuthorizationController.canMakePayments(
             usingNetworks: Payment.supportedNetworks,
             capabilities: Payment.capabilities) {
-            return ApplePaymentLabelType.setUp
+            return ButtonLabelType.setUp
         }
         return nil
     }
     
-    /// Sendable version of PayWithApplePayButtonLabel
-    private enum ApplePaymentLabelType: Sendable {
+    /// Sendable app-side representation of the Apple Pay button label.
+    enum ButtonLabelType: Sendable {
         case donate
         case setUp
     }
@@ -147,19 +146,11 @@ struct Payment {
     /// - Returns: Setup button if no cards added yet,
     /// nil if Apple Pay is not supported
     /// or donation button, if all is OK
-    static func paymentButtonTypeAsync() async -> PayWithApplePayButtonLabel? {
-        let task = Task<ApplePaymentLabelType?, Never>(priority: .low) {
+    static func paymentButtonTypeAsync() async -> ButtonLabelType? {
+        let task = Task<ButtonLabelType?, Never>(priority: .low) {
             Self.paymentButtonType()
         }
-        guard let buttonLabel = await task.result.get() else {
-            return nil
-        }
-        switch buttonLabel {
-        case .donate:
-            return PayWithApplePayButtonLabel.donate
-        case .setUp:
-            return PayWithApplePayButtonLabel.setUp
-        }
+        return await task.result.get()
     }
 
     func donationRequest(for selectedAmount: SelectedAmount) -> PKPaymentRequest {
@@ -190,6 +181,49 @@ struct Payment {
         return request
     }
 
+    @MainActor
+    func authorize(payment authorizedPayment: PKPayment,
+                   selectedAmount: SelectedAmount) async -> PKPaymentAuthorizationResult {
+        let paymentServer = StripeKiwix(endPoint: Self.kiwixPaymentServer)
+        do {
+            let publicKey = try await paymentServer.publishableKey()
+            StripeAPI.setDefault(publishableKey: publicKey)
+        } catch let serverError {
+            Self.finalResult = .error
+            return .init(status: .failure, errors: [serverError])
+        }
+        // we should update the return path for confirmations
+        // see: https://github.com/kiwix/kiwix-apple/issues/1032
+        let stripe = StripeApplePaySimple()
+        let endPoint = paymentServer.endPoint
+        let result = await stripe.complete(payment: authorizedPayment,
+                                           returnURLPath: nil,
+                                           usingClientSecretProvider: { @Sendable in
+            await StripeKiwix.clientSecretForPayment(endPoint: endPoint, selectedAmount: selectedAmount)
+        }, withAPI: StripeAsyncAPI())
+        switch result.status {
+        case .success:
+            Self.finalResult = .thankYou
+        case .failure:
+            Self.finalResult = .error
+        default:
+            Self.finalResult = nil
+        }
+        return result
+    }
+
+    @MainActor
+    func authorizationDidFinish() {
+        completeSubject.send(())
+    }
+
+    @MainActor
+    func authorizationPresentationDidFail() {
+        Self.finalResult = .error
+        completeSubject.send(())
+    }
+
+    #if os(iOS)
     func onPaymentAuthPhase(selectedAmount: SelectedAmount,
                             phase: PayWithApplePayButtonPaymentAuthorizationPhase) {
         switch phase {
@@ -197,47 +231,19 @@ struct Payment {
             Log.Payment.info("onPaymentAuthPhase: .willAuthorize")
         case .didAuthorize(let payment, let resultHandler):
             Log.Payment.info("onPaymentAuthPhase: .didAuthorize")
-            // call our server to get payment / setup intent and return the client.secret
             Task { @MainActor [resultHandler] in
-                let paymentServer = StripeKiwix(endPoint: Self.kiwixPaymentServer)
-                do {
-                    let publicKey = try await paymentServer.publishableKey()
-                    StripeAPI.setDefault(publishableKey: publicKey)
-                } catch let serverError {
-                    Self.finalResult = .error
-                    resultHandler(.init(status: .failure, errors: [serverError]))
-                    return
-                }
-                // we should update the return path for confirmations
-                // see: https://github.com/kiwix/kiwix-apple/issues/1032
-                let stripe = StripeApplePaySimple()
-                let endPoint = paymentServer.endPoint
-                let result = await stripe.complete(payment: payment,
-                                                   returnURLPath: nil,
-                                                   usingClientSecretProvider: { @Sendable in
-                    await StripeKiwix.clientSecretForPayment(endPoint: endPoint, selectedAmount: selectedAmount)
-                }, withAPI: StripeAsyncAPI())
-                // calling any UI refreshing state / subject from here
-                // will block the UI in the payment state forever
-                // therefore it's defered via static finalResult
-                switch result.status {
-                case .success:
-                    Self.finalResult = .thankYou
-                case .failure:
-                    Self.finalResult = .error
-                default:
-                    Self.finalResult = nil
-                }
+                let result = await authorize(payment: payment, selectedAmount: selectedAmount)
                 resultHandler(result)
                 Log.Payment.info("onPaymentAuthPhase: .didAuthorize: \(result.status == .success, privacy: .public)")
             }
         case .didFinish:
             Log.Payment.info("onPaymentAuthPhase: .didFinish")
-            completeSubject.send(())
+            authorizationDidFinish()
         @unknown default:
             Log.Payment.error("onPaymentAuthPhase: @unknown default")
         }
     }
+    #endif
 
     @MainActor
     func onMerchantSessionUpdate() async -> PKPaymentRequestMerchantSessionUpdate {
@@ -248,6 +254,33 @@ struct Payment {
         return .init(status: .success, merchantSession: session)
     }
 }
+
+#if os(iOS)
+extension Payment.ButtonLabelType {
+    @available(iOS 16.0, macOS 13.0, watchOS 9.0, *)
+    var payWithApplePayButtonLabel: PayWithApplePayButtonLabel {
+        switch self {
+        case .donate:
+            .donate
+        case .setUp:
+            .setUp
+        }
+    }
+}
+#endif
+
+#if os(macOS)
+extension Payment.ButtonLabelType {
+    var paymentButtonType: PKPaymentButtonType {
+        switch self {
+        case .donate:
+            .donate
+        case .setUp:
+            .setUp
+        }
+    }
+}
+#endif
 
 private enum MerchantSessionError: Error {
     case invalidStatus

--- a/Model/Payment.swift
+++ b/Model/Payment.swift
@@ -238,7 +238,9 @@ struct Payment {
             }
         case .didFinish:
             Log.Payment.info("onPaymentAuthPhase: .didFinish")
-            authorizationDidFinish()
+            Task { @MainActor in
+                authorizationDidFinish()
+            }
         @unknown default:
             Log.Payment.error("onPaymentAuthPhase: @unknown default")
         }

--- a/Views/Payment/PaymentSummary.swift
+++ b/Views/Payment/PaymentSummary.swift
@@ -14,8 +14,11 @@
 // along with Kiwix; If not, see https://www.gnu.org/licenses/.
 
 import SwiftUI
-import PassKit
 import Combine
+
+#if os(iOS) || os(macOS)
+import PassKit
+#endif
 
 struct PaymentSummary: View {
 
@@ -25,13 +28,25 @@ struct PaymentSummary: View {
     private let payment: Payment
     private let onComplete: @MainActor () -> Void
     @State private var paymentDetermined: Bool = false
-    @State private var paymentButtonLabel: PayWithApplePayButtonLabel?
+    @State private var paymentButtonLabel: Payment.ButtonLabelType?
+    #if os(macOS)
+    @State private var applePayCoordinator: MacApplePayCoordinator
+    #endif
 
     init(selectedAmount: SelectedAmount,
          onComplete: @escaping @MainActor () -> Void) {
         self.selectedAmount = selectedAmount
         self.onComplete = onComplete
-        payment = Payment()
+        let payment = Payment()
+        self.payment = payment
+        #if os(macOS)
+        _applePayCoordinator = State(
+            initialValue: MacApplePayCoordinator(
+                selectedAmount: selectedAmount,
+                payment: payment
+            )
+        )
+        #endif
     }
 
     var body: some View {
@@ -47,10 +62,11 @@ struct PaymentSummary: View {
                     .padding()
             }
             Text(selectedAmount.value.formatted(.currency(code: selectedAmount.currency))).font(.title).bold()
+            #if os(iOS)
             if paymentDetermined {
                 if let paymentButtonLabel {
                     PayWithApplePayButton(
-                        paymentButtonLabel,
+                        paymentButtonLabel.payWithApplePayButtonLabel,
                         request: payment.donationRequest(for: selectedAmount),
                         onPaymentAuthorizationChange: { phase in
                             payment.onPaymentAuthPhase(selectedAmount: selectedAmount,
@@ -68,6 +84,24 @@ struct PaymentSummary: View {
             } else {
                 LoadingProgressView()
             }
+            #elseif os(macOS)
+            if paymentDetermined {
+                if let paymentButtonLabel {
+                    MacApplePayButton(
+                        type: paymentButtonLabel.paymentButtonType,
+                        action: applePayCoordinator.present
+                    )
+                    .frame(width: 186, height: 44)
+                    .padding()
+                } else {
+                    Text(LocalString.payment_support_fallback_message)
+                        .foregroundStyle(.red)
+                        .font(.callout)
+                }
+            } else {
+                LoadingProgressView()
+            }
+            #endif
         }.onReceive(payment.completeSubject) {
             onComplete()
         }
@@ -75,8 +109,111 @@ struct PaymentSummary: View {
             paymentButtonLabel = await Payment.paymentButtonTypeAsync()
             paymentDetermined = true
         }
+        #if os(macOS)
+        .withHostingWindow { window in
+            applePayCoordinator.presentationWindow = window
+        }
+        #endif
     }
 }
+
+#if os(macOS)
+private struct MacApplePayButton: NSViewRepresentable {
+    let type: PKPaymentButtonType
+    let action: () -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(action: action)
+    }
+
+    func makeNSView(context: Context) -> PKPaymentButton {
+        let button = PKPaymentButton(paymentButtonType: type, paymentButtonStyle: .automatic)
+        button.target = context.coordinator
+        button.action = #selector(Coordinator.onTap)
+        return button
+    }
+
+    func updateNSView(_ button: PKPaymentButton, context: Context) {
+        button.target = context.coordinator
+        button.action = #selector(Coordinator.onTap)
+    }
+
+    final class Coordinator: NSObject {
+        private let action: () -> Void
+
+        init(action: @escaping () -> Void) {
+            self.action = action
+        }
+
+        @objc func onTap() {
+            action()
+        }
+    }
+}
+
+private final class MacApplePayCoordinator: NSObject, PKPaymentAuthorizationControllerDelegate, @unchecked Sendable {
+    let selectedAmount: SelectedAmount
+    let payment: Payment
+    var presentationWindow: NSWindow?
+
+    private var controller: PKPaymentAuthorizationController?
+
+    init(selectedAmount: SelectedAmount, payment: Payment) {
+        self.selectedAmount = selectedAmount
+        self.payment = payment
+    }
+
+    func present() {
+        let controller = PKPaymentAuthorizationController(paymentRequest: payment.donationRequest(for: selectedAmount))
+        controller.delegate = self
+        self.controller = controller
+        controller.present { [weak self] success in
+            guard let self, !success else { return }
+            Log.Payment.error("paymentAuthorizationController.presentWithCompletion failed")
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.controller = nil
+                self.payment.authorizationPresentationDidFail()
+            }
+        }
+    }
+
+    func paymentAuthorizationControllerDidFinish(_ controller: PKPaymentAuthorizationController) {
+        controller.dismiss { [weak self] in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.controller = nil
+                self.payment.authorizationDidFinish()
+            }
+        }
+    }
+
+    func paymentAuthorizationControllerWillAuthorizePayment(_ controller: PKPaymentAuthorizationController) {
+        Log.Payment.info("paymentAuthorizationController: will authorize")
+    }
+
+    func paymentAuthorizationController(_ controller: PKPaymentAuthorizationController,
+                                        didRequestMerchantSessionUpdate handler: @escaping (PKPaymentRequestMerchantSessionUpdate) -> Void) {
+        Task { @MainActor [payment] in
+            handler(await payment.onMerchantSessionUpdate())
+        }
+    }
+
+    func paymentAuthorizationController(_ controller: PKPaymentAuthorizationController,
+                                        didAuthorizePayment authorizedPayment: PKPayment,
+                                        handler: @escaping (PKPaymentAuthorizationResult) -> Void) {
+        Task { @MainActor [payment, selectedAmount] in
+            let result = await payment.authorize(payment: authorizedPayment, selectedAmount: selectedAmount)
+            handler(result)
+            Log.Payment.info("paymentAuthorizationController: didAuthorize: \(result.status == .success, privacy: .public)")
+        }
+    }
+
+    func presentationWindow(for controller: PKPaymentAuthorizationController) -> NSWindow? {
+        presentationWindow
+    }
+}
+#endif
 
 #Preview {
     PaymentSummary(

--- a/Views/Payment/PaymentSummary.swift
+++ b/Views/Payment/PaymentSummary.swift
@@ -192,8 +192,10 @@ private final class MacApplePayCoordinator: NSObject, PKPaymentAuthorizationCont
         Log.Payment.info("paymentAuthorizationController: will authorize")
     }
 
-    func paymentAuthorizationController(_ controller: PKPaymentAuthorizationController,
-                                        didRequestMerchantSessionUpdate handler: @escaping (PKPaymentRequestMerchantSessionUpdate) -> Void) {
+    func paymentAuthorizationController(
+        _ controller: PKPaymentAuthorizationController,
+        didRequestMerchantSessionUpdate handler: @escaping (PKPaymentRequestMerchantSessionUpdate) -> Void
+    ) {
         Task { @MainActor [payment] in
             handler(await payment.onMerchantSessionUpdate())
         }
@@ -203,9 +205,14 @@ private final class MacApplePayCoordinator: NSObject, PKPaymentAuthorizationCont
                                         didAuthorizePayment authorizedPayment: PKPayment,
                                         handler: @escaping (PKPaymentAuthorizationResult) -> Void) {
         Task { @MainActor [payment, selectedAmount] in
-            let result = await payment.authorize(payment: authorizedPayment, selectedAmount: selectedAmount)
+            let result = await payment.authorize(
+                payment: authorizedPayment,
+                selectedAmount: selectedAmount
+            )
             handler(result)
-            Log.Payment.info("paymentAuthorizationController: didAuthorize: \(result.status == .success, privacy: .public)")
+            Log.Payment.info(
+                "paymentAuthorizationController: didAuthorize: \(result.status == .success, privacy: .public)"
+            )
         }
     }
 

--- a/Views/Settings/Settings.swift
+++ b/Views/Settings/Settings.swift
@@ -164,7 +164,7 @@ struct Settings: View {
     @EnvironmentObject private var colorSchemeStore: UserColorSchemeStore
     @EnvironmentObject private var library: LibraryViewModel
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
-    @State private var paymentButtonLabel: PayWithApplePayButtonLabel?
+    @State private var paymentButtonLabel: Payment.ButtonLabelType?
 
     enum Route {
         case languageSelector, about


### PR DESCRIPTION
Crashed on my Intel Mac: fixes a macOS launch crash caused by the SwiftUI Apple Pay API on some macOS runtimes.

  The failing path used `PayWithApplePayButton` / `PayWithApplePayButtonLabel` directly on macOS. On at least macOS 14.6.1, that can abort at launch with a missing `_PassKit_SwiftUI` symbol before the app becomes usable.

  This PR keeps donations enabled on macOS, but switches the macOS implementation to native PassKit APIs instead of the SwiftUI Apple Pay view.
