### PR TITLE
Add macOS Downloads settings

### DIFF
--- a/App/App_macOS.swift
+++ b/App/App_macOS.swift
@@ -127,8 +127,9 @@ struct Kiwix: App {
                         .environmentObject(libraryRefreshViewModel)
                         .tag(SettingsTab.catalog.rawValue)
                 }
-                DownloadsMacOsSettings()
-                    .tag(SettingsTab.downloads.rawValue)
+//                enable as part of: https://github.com/kiwix/kiwix-apple/issues/1549
+//                DownloadsMacOsSettings()
+//                    .tag(SettingsTab.downloads.rawValue)
                 HotspotSettings()
                     .tag(SettingsTab.hotspot.rawValue)
                 About()

--- a/App/App_macOS.swift
+++ b/App/App_macOS.swift
@@ -32,6 +32,7 @@ enum SettingsTab: Int {
     case hotspot
     case about
     case diagnostics
+    case downloads
 }
 
 @main
@@ -126,6 +127,8 @@ struct Kiwix: App {
                         .environmentObject(libraryRefreshViewModel)
                         .tag(SettingsTab.catalog.rawValue)
                 }
+                DownloadsMacOsSettings()
+                    .tag(SettingsTab.downloads.rawValue)
                 HotspotSettings()
                     .tag(SettingsTab.hotspot.rawValue)
                 About()

--- a/Model/Downloads/DownloadDestination.swift
+++ b/Model/Downloads/DownloadDestination.swift
@@ -35,6 +35,12 @@ enum DownloadDestination {
         return directory
     }
     
+    #if os(macOS)
+    static func isUsersDefaultDownloads(directory: URL?) -> Bool {
+        directory?.resolvingSymlinksInPath() == downloadLocalFolder()?.resolvingSymlinksInPath()
+    }
+    #endif
+    
     static func filePathFor(downloadURL: URL) -> URL? {
         downloadLocalFolder()?.appendingPathComponent(downloadURL.lastPathComponent)
     }

--- a/Model/Downloads/DownloadLocationMac.swift
+++ b/Model/Downloads/DownloadLocationMac.swift
@@ -1,0 +1,89 @@
+// This file is part of Kiwix for iOS & macOS.
+//
+// Kiwix is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// any later version.
+//
+// Kiwix is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kiwix; If not, see https://www.gnu.org/licenses/.
+
+#if os(macOS)
+
+import Defaults
+import Foundation
+
+struct DownloadLocationMac {
+    let directory: URL?
+    let isDefault: Bool
+    let urlDescription: String
+    
+    static func load() -> Self {
+        if let savedBookmark = MacDefaults.loadBookmark() {
+            let urlState = savedBookmark.resolveBookmarkWithSecurityScope()
+            switch urlState {
+            case let .url(.some(url)):
+                Log.DownloadService.debug("loaded downloads url: \(url.path(), privacy: .private)")
+                return DownloadLocationMac(directory: url)
+            case .url(.none):
+                Log.DownloadService.warning("Unable to set the saved download url")
+                return Self.default()
+            case let .refreshed(newData, url):
+                Log.DownloadService.debug("loaded downloads url with fresh bookmarks: \(url.path(), privacy: .private)")
+                MacDefaults.saveBookmark(data: newData)
+                return DownloadLocationMac(directory: url)
+            }
+        }
+        return Self.default()
+    }
+    
+    static func `default`() -> Self {
+        DownloadLocationMac(directory: DownloadDestination.downloadLocalFolder())
+    }
+    
+    init(directory: URL?) {
+        self.directory = directory
+        urlDescription = directory?.resolvingSymlinksInPath().path() ?? LocalString.download_mac_folder_unknown
+        isDefault = DownloadDestination.isUsersDefaultDownloads(directory: directory)
+    }
+    
+    nonisolated func volumeAndSpace() async -> String {
+        let space: String? = if let space = directory?.availableSpace() {
+            ByteCountFormatter.string(fromByteCount: space, countStyle: .file)
+        } else {
+            nil
+        }
+        let volume = directory?.volumeName()
+        return [volume, space].compactMap { $0 }.joined(separator: "  ")
+    }
+    
+    func save() -> Bool {
+        if isDefault {
+            // for some reasons the default downloads folder is not bookmarkable, using nil instead
+            MacDefaults.saveBookmark(data: nil)
+            return true
+        }
+        guard let directory,
+              let bookmarkData = directory.bookmarkDataWithSecurityScope() else {
+            return false
+        }
+        MacDefaults.saveBookmark(data: bookmarkData)
+        Log.DownloadService.debug("saved url: \(directory.path(), privacy: .private)")
+        return true
+    }
+}
+
+private enum MacDefaults {
+    static func saveBookmark(data: Data?) {
+        Defaults[.downloadsMacDirectoryBookmark] = data
+    }
+    static func loadBookmark() -> Data? {
+        Defaults[.downloadsMacDirectoryBookmark]
+    }
+}
+#endif

--- a/Model/Utilities/Data+Extension.swift
+++ b/Model/Utilities/Data+Extension.swift
@@ -1,0 +1,43 @@
+// This file is part of Kiwix for iOS & macOS.
+//
+// Kiwix is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// any later version.
+//
+// Kiwix is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kiwix; If not, see https://www.gnu.org/licenses/.
+
+import Foundation
+
+#if os(macOS)
+
+enum BookmarkState {
+    case url(URL?)
+    case refreshed(newData: Data?, url: URL)
+}
+
+extension Data {
+    func resolveBookmarkWithSecurityScope() -> BookmarkState {
+        do {
+            var isStale = false
+            let url = try URL(resolvingBookmarkData: self,
+                              options: .withSecurityScope,
+                              bookmarkDataIsStale: &isStale)
+            if isStale {
+                let freshBookmarkData = url.bookmarkDataWithSecurityScope()
+                return .refreshed(newData: freshBookmarkData, url: url)
+            }
+            return .url(url)
+        } catch {
+            return .url(nil)
+        }
+    }
+}
+
+#endif

--- a/Model/Utilities/URL.swift
+++ b/Model/Utilities/URL.swift
@@ -116,4 +116,43 @@ extension URL {
         components.queryItems = nil
         return components.url ?? self
     }
+    
+    #if os(macOS)
+    func volumeName() -> String? {
+        let needsScope = startAccessingSecurityScopedResource()
+        defer { if needsScope { stopAccessingSecurityScopedResource() } }
+        return try? resourceValues(forKeys: [.volumeNameKey]).volumeName
+    }
+    
+    func availableSpace() -> Int64? {
+        let needsScope = startAccessingSecurityScopedResource()
+        defer { if needsScope { stopAccessingSecurityScopedResource() } }
+        do {
+            let resourceValues = try resourceValues(forKeys: [
+                .volumeAvailableCapacityForImportantUsageKey,
+                .volumeAvailableCapacityKey
+            ])
+            if let available = resourceValues.volumeAvailableCapacityForImportantUsage, available > 0 {
+                return available
+            }
+            // Fallback when accounts for purgeable space (APFS) is not supported
+            if let available = resourceValues.volumeAvailableCapacity {
+                return Int64(available)
+            }
+            return nil
+        } catch {
+            Log.DownloadService.warning(
+                "Could not determine available disk space: \(error.localizedDescription, privacy: .public)"
+            )
+            return nil
+        }
+    }
+    
+    func bookmarkDataWithSecurityScope() -> Data? {
+        let needsScope = startAccessingSecurityScopedResource()
+        defer { if needsScope { stopAccessingSecurityScopedResource() } }
+        return try? bookmarkData(options: .withSecurityScope)
+    }
+    
+    #endif
 }

--- a/Support/en.lproj/Localizable.strings
+++ b/Support/en.lproj/Localizable.strings
@@ -241,9 +241,18 @@
 "settings.about.source.title" = "Source";
 "settings.about.button.license" = "GNU General Public License v3";
 
+"download_mac_settings.tab.title" = "Downloads";
+
+"download_mac_folder.button.change" = "Change";
+"download_mac_folder.button.reset" = "Reset to default";
+"download_mac_folder.unknown" = "Unknown";
+"download_mac_folder.panel.message" = "Select a folder for ZIM downloads";
+"download_mac_folder.error.title" = "Can't use this folder.";
+"download_mac_folder.error.not_writable" = "You don't have permission to save files here.";
+"download_mac_folder.error.save_failed" = "Couldn't set the download folder. Try again.";
+
 "bookmark.navigation.title" = "Bookmarks";
 "bookmark.overlay.empty.title" = "No bookmarks";
-
 
 "search_result.zimfile.empty.message" = "No opened ZIM file";
 "search_result.zimfile.no_result.message" = "No result";
@@ -360,7 +369,7 @@
 "download_service.error.client.serverCertificateNotYetValid" = "The certificate for this server is not yet valid.";
 "download_service.error.client.clientCertificateRejected" = "The server did not accept the certificate.";
 "download_service.error.client.clientCertificateRequired" = "The server requires a client certificate.";
-"download_service.error.client.cannotLoadFromNetwork" = "can’t load from network";
+"download_service.error.client.cannotLoadFromNetwork" = "can't load from network";
 "download_service.error.client.cannotCreateFile" = "Cannot create file";
 "download_service.error.client.cannotOpenFile" = "Cannot open file";
 "download_service.error.client.cannotCloseFile" = "Failure occurred while closing file";

--- a/Support/qqq.lproj/Localizable.strings
+++ b/Support/qqq.lproj/Localizable.strings
@@ -322,3 +322,12 @@
 "download_service.error.client.cannotMoveFile" = "Additional description of the download alert pop up, describing the specific system error, that occured.";
 "download_service.error.client.downloadDecodingFailedMidStream" = "Additional description of the download alert pop up, describing the specific system error, that occured.";
 "download_service.error.client.downloadDecodingFailedToComplete" = "Additional description of the download alert pop up, describing the specific system error, that occured.";
+
+"download_mac_settings.tab.title" = "Settings page tab title";
+"download_mac_folder.button.change" = "Button title to change the download folder, where the ZIM files will be saved. Displayed below the currently selected folder path.";
+"download_mac_folder.button.reset" = "Button title to reset the changed download folder to the default location. Displayed below the currently selected folder path.";
+"download_mac_folder.unknown" = "A fallback title, if for some reason the currently selected path cannot be displayed.";
+"download_mac_folder.panel.message" = "File browser panel pop up title, when the user is in the process of selecting the desired folder, where the ZIM files will be saved.";
+"download_mac_folder.error.title" = "Error alert pop-up title, when the selected folder cannot be used.";
+"download_mac_folder.error.not_writable" = "Error alert pop-up message, when the selected folder is not writable by the application, therefore not suitable as a downloads folder.";
+"download_mac_folder.error.save_failed" = "Error alert pop-up message, the selected folder is not reachable by the application, therefore not suitable as a downloads folder.";

--- a/SwiftUI/Model/DefaultKeys.swift
+++ b/SwiftUI/Model/DefaultKeys.swift
@@ -54,6 +54,8 @@ extension Defaults.Keys {
     #if os(macOS)
     // window management:
     static let windowURLs = Key<[URL]>("windowURLs", default: [])
+    /// selected downloads directory, encoded via url.bookmarkData
+    static let downloadsMacDirectoryBookmark = Key<Data?>("downloadsMacDirectoryBookmark")
     #endif
     
     #if os(iOS)

--- a/Views/Settings/DownloadsMacOsLocationPicker.swift
+++ b/Views/Settings/DownloadsMacOsLocationPicker.swift
@@ -1,0 +1,121 @@
+// This file is part of Kiwix for iOS & macOS.
+//
+// Kiwix is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// any later version.
+//
+// Kiwix is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kiwix; If not, see https://www.gnu.org/licenses/.
+
+#if os(macOS)
+import SwiftUI
+
+struct DownloadsMacOsLocationPicker: View {
+    @State private var location = DownloadLocationMac.load()
+    @State private var volumeAndSpace: String?
+    
+    var body: some View {
+        HStack(alignment: .top) {
+            VStack(alignment: .leading) {
+                Text(location.urlDescription)
+                    .font(.system(.body, design: .monospaced))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                
+                if let volumeAndSpace {
+                    Label(volumeAndSpace, systemImage: "internaldrive")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                
+                HStack(spacing: 8) {
+                    Button(LocalString.download_mac_folder_button_change) {
+                        changeDirectory()
+                    }
+                    if !location.isDefault {
+                        Button(LocalString.download_mac_folder_button_reset) {
+                            resetToDefault()
+                        }
+                        .foregroundColor(.secondary)
+                    }
+                }
+                .padding(.top, 8)
+            }
+            
+            Spacer()
+        }
+        .onAppear {
+            location = DownloadLocationMac.load()
+            refreshVolumeAndSpace()
+        }
+    }
+    
+    // MARK: - Actions
+    
+    private func changeDirectory() {
+        let panel = NSOpenPanel()
+        panel.message = LocalString.download_mac_folder_panel_message
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.canCreateDirectories = true
+        panel.allowsMultipleSelection = false
+        
+        // Start in the current directory if available
+        if let currentDir = location.directory {
+            panel.directoryURL = currentDir
+        }
+        
+        panel.begin { response in
+            if response == .OK, let url = panel.url {
+                setUserDefinedDir(url)
+            }
+        }
+    }
+    
+    private func setUserDefinedDir(_ url: URL) {
+        guard FileManager.default.isWritableFile(atPath: url.path()) else {
+            return showAlert(message: LocalString.download_mac_folder_error_title,
+                             description: LocalString.download_mac_folder_error_not_writable)
+        }
+        location = DownloadLocationMac(directory: url)
+        saveLocation()
+    }
+    
+    private func resetToDefault() {
+        location = DownloadLocationMac.default()
+        saveLocation()
+    }
+    
+    private func saveLocation() {
+        if !location.save() {
+            showAlert(message: LocalString.download_mac_folder_error_title,
+                      description: LocalString.download_mac_folder_error_save_failed)
+        }
+        refreshVolumeAndSpace()
+    }
+    
+    private func refreshVolumeAndSpace() {
+        Task.detached(priority: .utility) {
+            let value = await location.volumeAndSpace()
+            await MainActor.run { volumeAndSpace = value }
+        }
+    }
+    
+    private func showAlert(message: String, description: String) {
+        let alert = NSAlert()
+        alert.messageText = message
+        alert.informativeText = description
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: LocalString.common_button_ok)
+        alert.runModal()
+        return
+    }
+}
+
+#endif

--- a/Views/Settings/DownloadsMacOsSettings.swift
+++ b/Views/Settings/DownloadsMacOsSettings.swift
@@ -1,0 +1,31 @@
+// This file is part of Kiwix for iOS & macOS.
+//
+// Kiwix is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// any later version.
+//
+// Kiwix is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kiwix; If not, see https://www.gnu.org/licenses/.
+
+#if os(macOS)
+import SwiftUI
+
+struct DownloadsMacOsSettings: View {
+    var body: some View {
+        VStack(alignment: .leading) {
+            DownloadsMacOsLocationPicker()
+            
+            Spacer()
+        }
+        .padding(.vertical)
+        .padding(.horizontal, 32)
+        .tabItem { Label(LocalString.download_mac_settings_tab_title, systemImage: "arrow.down.circle") }
+    }
+}
+#endif


### PR DESCRIPTION
# macOS Downloads Settings
Related to: #627

## Screenshots
<img width="662" height="600" alt="Screenshot 2026-04-12 at 12 51 53" src="https://github.com/user-attachments/assets/de8ca4c7-62a4-4fa0-aa3e-51437b7720a2" />

<img width="662" height="600" alt="Screenshot 2026-04-12 at 12 52 03" src="https://github.com/user-attachments/assets/210e47ca-7737-423c-9c16-faa6206fc60c" />


## Possible error messages:
<img width="372" height="330" alt="Screenshot 2026-04-12 at 11 06 26" src="https://github.com/user-attachments/assets/3b568503-ae66-4d34-b382-f889e1ef4430" />
<img width="372" height="330" alt="Screenshot 2026-04-12 at 11 05 37" src="https://github.com/user-attachments/assets/7edb5f8b-393d-4a56-a5d9-b1686209cd6f" />


## Performance:
Measured and moved this to be off the UI thread:
- getting the disk volume name the available space: (max) 29ms