### PR TITLE
Allow location sharing

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -24,6 +24,8 @@ settings:
     INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone: UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight
     INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad: UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight
     INFOPLIST_KEY_NSPhotoLibraryUsageDescription: "Kiwix needs permission to saves images to your photos app."
+    INFOPLIST_KEY_NSLocationWhenInUseUsageDescription: "Kiwix can share your location with map content from ZIM files you open."
+    INFOPLIST_KEY_NSLocationUsageDescription: "Kiwix can share your location with map content from ZIM files you open."
     INFOPLIST_KEY_LSSupportsOpeningDocumentsInPlace: YES
     INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents: YES
     SWIFT_OBJC_INTEROP_MODE: objcxx
@@ -67,6 +69,7 @@ targetTemplates:
         com.apple.security.network.client: true
         com.apple.security.network.server: true
         com.apple.security.print: true
+        com.apple.security.personal-information.location: true
     dependencies:
       - framework: CoreKiwix.xcframework
         embed: false


### PR DESCRIPTION
Fixes: #1560 

Superseeds #1554 

@kelson42 you were right!
It's enough to just enable the location services and it works out of the box:

## Simulated driving in California, with request prompt:

https://github.com/user-attachments/assets/cc31b0d6-f4e8-4997-b95b-04fbabedc8be

-------

## Disabling location, gives a crossed out location icon:
<img width="589" height="1280" alt="no_location" src="https://github.com/user-attachments/assets/e4adcf23-8727-4e26-a476-4d6c7e50c937" />


