### PR TITLE
Add geolocation api

### DIFF
--- a/Model/Geolocation/GeolocationService.swift
+++ b/Model/Geolocation/GeolocationService.swift
@@ -1,0 +1,210 @@
+// This file is part of Kiwix for iOS & macOS.
+//
+// Kiwix is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// any later version.
+//
+// Kiwix is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kiwix; If not, see https://www.gnu.org/licenses/.
+
+import CoreLocation
+import Foundation
+
+/// Groups the Geolocation response types we send to JS
+protocol JSRespondable {
+    var jsResponse: [String: Any] { get }
+}
+
+private enum GeolocationError: Int, Error, JSRespondable {
+    // Matching the DOM equivalent from:
+    // https://www.w3.org/TR/geolocation/#dom-geolocationpositionerror
+    case permissionDenied = 1
+    case positionUnavailable = 2
+    case timeout = 3
+
+    var localizedDescription: String {
+        switch self {
+        case .permissionDenied: return LocalString.geolocation_error_permission_denied
+        case .positionUnavailable: return LocalString.geolocation_error_position_unavailable
+        case .timeout: return LocalString.geolocation_error_timeout
+        }
+    }
+
+    var jsResponse: [String: Any] {
+        ["error": ["code": rawValue, "message": localizedDescription]]
+    }
+}
+
+private struct GeolocationResponse: JSRespondable {
+    struct Vertical {
+        let altitude: Double
+        let accuracy: Double
+    }
+    let latitude: Double
+    let longitude: Double
+    let horizontalAccuracy: Double
+    let vertical: Vertical?
+    let course: Double?
+    let speed: Double?
+    let timestamp: Date
+
+    init(_ location: CLLocation) {
+        latitude = location.coordinate.latitude
+        longitude = location.coordinate.longitude
+        horizontalAccuracy = location.horizontalAccuracy
+        if location.verticalAccuracy >= 0 {
+            vertical = Vertical(altitude: location.altitude, accuracy: location.verticalAccuracy)
+        } else {
+            vertical = nil
+        }
+        course = location.course >= 0 ? location.course : nil
+        speed = location.speed >= 0 ? location.speed : nil
+        timestamp = location.timestamp
+    }
+
+    var jsResponse: [String: Any] {
+        var coords: [String: Any] = [
+            "latitude": latitude,
+            "longitude": longitude,
+            "accuracy": horizontalAccuracy
+        ]
+        if let vertical {
+            coords["altitude"] = vertical.altitude
+            coords["altitudeAccuracy"] = vertical.accuracy
+        }
+        if let course { coords["heading"] = course }
+        if let speed { coords["speed"] = speed }
+        return [
+            "coords": coords,
+            "timestamp": timestamp.timeIntervalSince1970 * 1000
+        ]
+    }
+}
+
+/// The incoming Geolocation request from JS
+struct GeolocationRequest: Hashable {
+    let id: UInt
+    let type: RequestMethod
+    let highAccuracy: Bool
+    
+    enum RequestMethod: String {
+        case getCurrentPosition
+        case watchPosition
+        case clearWatch
+    }
+    
+    init?(jsRequest payload: [String: Any]) {
+        guard let payloadType = payload["type"] as? String,
+              let requestMethod = RequestMethod(rawValue: payloadType),
+              let requestId = payload["id"] as? UInt else { return nil }
+        id = requestId
+        type = requestMethod
+        highAccuracy = (payload["highAccuracy"] as? NSNumber)?.boolValue ?? false
+    }
+}
+
+@MainActor
+final class GeolocationService: NSObject, @MainActor CLLocationManagerDelegate {
+    private let onResult: @MainActor (JSRespondable) -> Void
+    private var watchRequests = Set<UInt>()
+    private var oneTimeRequests = Set<UInt>()
+    private var task: Task<Void, Error>?
+    private let manager = CLLocationManager()
+    private var cachedLocation: CLLocation?
+    
+    init(onResult: @escaping @MainActor (JSRespondable) -> Void) {
+        self.onResult = onResult
+        super.init()
+        manager.delegate = self
+    }
+    
+    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        switch manager.authorizationStatus {
+        case .authorized, .authorizedAlways:
+            break
+        case .restricted, .denied:
+            onResult(GeolocationError.permissionDenied)
+            stopAll()
+        case .notDetermined:
+            manager.requestWhenInUseAuthorization()
+        default:
+            break
+        }
+    }
+    
+    func handle(request: GeolocationRequest) {
+        switch request.type {
+        case .clearWatch:
+            // remove watch by id
+            watchRequests = watchRequests.filter { $0 != request.id }
+        case .getCurrentPosition:
+            oneTimeRequests.insert(request.id)
+            sendCachedLocation()
+        case .watchPosition:
+            watchRequests.insert(request.id)
+            sendCachedLocation()
+        }
+        didUpdateRequests()
+    }
+    
+    func stopAll() {
+        stop()
+        watchRequests.removeAll()
+        oneTimeRequests.removeAll()
+    }
+    
+    private func didUpdateRequests() {
+        if watchRequests.isEmpty, oneTimeRequests.isEmpty {
+            stop()
+        } else {
+            start()
+        }
+    }
+    
+    private func sendCachedLocation() {
+        guard let cachedLocation else { return }
+        let timeDiff = Date().timeIntervalSince(cachedLocation.timestamp)
+        if timeDiff < 300 {
+            onResult(GeolocationResponse(cachedLocation))
+        } else {
+            self.cachedLocation = nil
+        }
+    }
+    
+    private func start() {
+        guard task == nil else { return }
+        task = Task {
+            do {
+                for try await update in CLLocationUpdate.liveUpdates() {
+                    guard !Task.isCancelled else { break }
+                    if let location = update.location {
+                        // store it in cache
+                        cachedLocation = location
+                        onResult(GeolocationResponse(location))
+                        // fired once, now remove them
+                        oneTimeRequests.removeAll()
+                        didUpdateRequests()
+                    } else {
+                        if watchRequests.isEmpty {
+                            onResult(GeolocationError.positionUnavailable)
+                        }
+                    }
+                }
+            } catch {
+                Log.Geolocation.warning("GeolocationService error: \(error.localizedDescription)")
+                onResult(GeolocationError.timeout)
+            }
+        }
+    }
+    
+    private func stop() {
+        task?.cancel()
+        task = nil
+    }
+}

--- a/Model/Utilities/Log.swift
+++ b/Model/Utilities/Log.swift
@@ -25,6 +25,7 @@ struct Log {
     static let URLSchemeHandler = Logger(subsystem: subsystem, category: "URLSchemeHandler")
     static let Branding = Logger(subsystem: subsystem, category: "Branding")
     static let Payment = Logger(subsystem: subsystem, category: "Payment")
+    static let Geolocation = Logger(subsystem: subsystem, category: "Geolocation")
 }
 
 private let subsystem = KiwixLogger.subsystem

--- a/Model/WebViewConfig/WebViewConfiguration.swift
+++ b/Model/WebViewConfig/WebViewConfiguration.swift
@@ -31,10 +31,17 @@ final class WebViewConfiguration: WKWebViewConfiguration {
             if let ruleList = WebContentBlocker.ruleList {
                 controller.add(ruleList)
             }
-            if let url = Bundle.main.url(forResource: "injection", withExtension: "js"),
-               let javascript = try? String(contentsOf: url) {
-                let script = WKUserScript(source: javascript, injectionTime: .atDocumentEnd, forMainFrameOnly: false)
-                controller.addUserScript(script)
+            // inject custom (bundled) .js files
+            for resource in ["injection", "geolocation"] {
+                if let url = Bundle.main.url(forResource: resource, withExtension: "js"),
+                   let javascript = try? String(contentsOf: url) {
+                    let script = WKUserScript(
+                        source: javascript,
+                        injectionTime: .atDocumentStart,
+                        forMainFrameOnly: false
+                    )
+                    controller.addUserScript(script)
+                }
             }
             return controller
         }()

--- a/Support/en.lproj/Localizable.strings
+++ b/Support/en.lproj/Localizable.strings
@@ -378,3 +378,6 @@
 "download_service.error.client.cannotMoveFile" = "Cannot move file";
 "download_service.error.client.downloadDecodingFailedMidStream" = "Download decoding failed";
 "download_service.error.client.downloadDecodingFailedToComplete" = "Download decoding failed";
+"geolocation_error.permission_denied" = "User denied geolocation permission.";
+"geolocation_error.position_unavailable" = "Location is unavailable.";
+"geolocation_error.timeout" = "Location request timed out.";

--- a/Support/geolocation.js
+++ b/Support/geolocation.js
@@ -1,0 +1,121 @@
+// Bridge the HTML5 Geolocation API to CoreLocation via a script message handler.
+// This lets map ZIM files use navigator.geolocation; The native side prompts the user for CoreLocation
+// permission on first use. Supports both getCurrentPosition (one-shot) and
+// watchPosition (continuous).
+(function () {
+    const handler = window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.geolocation;
+    if (!handler) {
+        // Surface installation state explicitly so the Web Inspector can tell
+        // "not installed" apart from "script never ran".
+        window.__kiwixGeolocationShimInstalled = false;
+        return;
+    }
+
+    let pending = new Array();
+    let nextId = 1;
+
+    function deliverSuccess(success, payload) {
+        if (typeof success !== "function") {
+            return;
+        }
+        success({
+            coords: {
+                latitude: payload.coords.latitude,
+                longitude: payload.coords.longitude,
+                accuracy: payload.coords.accuracy,
+                altitude: payload.coords.altitude ?? null,
+                altitudeAccuracy: payload.coords.altitudeAccuracy ?? null,
+                heading: payload.coords.heading ?? null,
+                speed: payload.coords.speed ?? null,
+            },
+            timestamp: payload.timestamp,
+        });
+    }
+
+    function deliverError(error, err) {
+        if (typeof error !== "function") {
+            return;
+        }
+        error({
+            code: err.code,
+            message: err.message,
+            PERMISSION_DENIED: 1,
+            POSITION_UNAVAILABLE: 2,
+            TIMEOUT: 3,
+        });
+    }
+
+    window.__kiwixGeolocationResolve = function (payload) {
+        if (payload && payload.coords) {
+            pending.forEach((entry) => {
+                deliverSuccess(entry.success, payload);
+            });
+        } else if (payload && payload.error) {
+            pending.forEach((entry) => {
+                deliverError(entry.error, payload.error);
+            });
+            if (payload.error.code === 1) {
+                // on permission denied, clear out all pending
+                pending = new Array();
+                return;
+            }
+        }
+        // remove all one-shot requests, they have been served
+        pending = pending.filter((entry) => entry.isWatch == true);
+    };
+
+    function getCurrentPosition(success, error, options) {
+        const id = nextId++;
+        const entry = { id: id, success: success, error: error, isWatch: false };
+        pending.push(entry);
+        handler.postMessage({
+            type: "getCurrentPosition",
+            id: id,
+            highAccuracy: !!(options && options.enableHighAccuracy),
+        });
+    }
+
+    function watchPosition(success, error, options) {
+        const id = nextId++;
+        const entry = { id: id, success: success, error: error, isWatch: true };
+        pending.push(entry);
+        handler.postMessage({
+            type: "watchPosition",
+            id: id,
+            highAccuracy: !!(options && options.enableHighAccuracy),
+        });
+        return id;
+    }
+
+    function clearWatch(id) {
+        pending = pending.filter((entry) => { entry.id !== id });
+        handler.postMessage({ type: "clearWatch", id: id });
+    }
+
+    const shim = {
+        getCurrentPosition: getCurrentPosition,
+        watchPosition: watchPosition,
+        clearWatch: clearWatch,
+    };
+    let installed = false;
+    try {
+        Object.defineProperty(navigator, "geolocation", {
+            configurable: true,
+            value: shim,
+        });
+        installed = true;
+    } catch (_) {
+        try {
+            // Some hardened runtimes mark navigator.geolocation non-configurable
+            // on the instance; the prototype property is still replaceable.
+            Object.defineProperty(Object.getPrototypeOf(navigator), "geolocation", {
+                configurable: true,
+                value: shim,
+            });
+            installed = true;
+        } catch (_) {
+            // Native navigator.geolocation stays in place.
+        }
+    }
+    window.__kiwixGeolocationShimInstalled = installed;
+})();

--- a/Support/qqq.lproj/Localizable.strings
+++ b/Support/qqq.lproj/Localizable.strings
@@ -330,3 +330,6 @@
 "download_service.error.client.cannotMoveFile" = "Additional description of the download alert pop up, describing the specific system error, that occured.";
 "download_service.error.client.downloadDecodingFailedMidStream" = "Additional description of the download alert pop up, describing the specific system error, that occured.";
 "download_service.error.client.downloadDecodingFailedToComplete" = "Additional description of the download alert pop up, describing the specific system error, that occured.";
+"geolocation_error.permission_denied" = "Error message returned to a ZIM web page when the user has denied geolocation permission.";
+"geolocation_error.position_unavailable" = "Error message returned to a ZIM web page when CoreLocation reports the location is unavailable (e.g. no satellites).";
+"geolocation_error.timeout" = "Error message returned to a ZIM web page when a geolocation request times out.";

--- a/ViewModel/BrowserViewModel.swift
+++ b/ViewModel/BrowserViewModel.swift
@@ -101,6 +101,7 @@ import CoreKiwix
 #endif
     let webView: WKWebView
     let tabID: NSManagedObjectID
+    private var geolocationService: GeolocationService?
     private var isLoadingObserver: NSKeyValueObservation?
     private var canGoBackObserver: NSKeyValueObservation?
     private var canGoForwardObserver: NSKeyValueObservation?
@@ -132,6 +133,8 @@ import CoreKiwix
         webView.configuration.defaultWebpagePreferences.preferredContentMode = .mobile // for font adjustment to work
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "headings")
         webView.configuration.userContentController.add(self, name: "headings")
+        webView.configuration.userContentController.removeScriptMessageHandler(forName: "geolocation")
+        webView.configuration.userContentController.add(self, name: "geolocation")
         webView.navigationDelegate = self
         webView.uiDelegate = self
 
@@ -187,8 +190,10 @@ import CoreKiwix
         canGoForwardObserver?.invalidate()
         titleURLObserver?.cancel()
         isLoadingObserver?.invalidate()
+        geolocationService?.stopAll()
         let contentController = webView.configuration.userContentController
         contentController.removeScriptMessageHandler(forName: "headings")
+        contentController.removeScriptMessageHandler(forName: "geolocation")
         contentController.removeAllUserScripts()
         webView.navigationDelegate = nil
         webView.uiDelegate = nil
@@ -501,6 +506,11 @@ import CoreKiwix
         decisionHandler(.allow)
     }
 
+    func webView(_ webView: WKWebView, didCommit _: WKNavigation!) {
+        // The previous document's geolocation callbacks are gone
+        geolocationService?.stopAll()
+    }
+
     @MainActor
     func webView(_ webView: WKWebView, didFinish _: WKNavigation!) {
         webView.evaluateJavaScript("expandAllDetailTags(); getOutlineItems();")
@@ -548,6 +558,42 @@ import CoreKiwix
         if message.name == "headings", let headings = message.body as? [[String: String]] {
             self.generateOutlineList(headings: headings)
             self.generateOutlineTree(headings: headings)
+        } else if message.name == "geolocation", let body = message.body as? [String: Any] {
+            guard let request = GeolocationRequest(jsRequest: body) else { return }
+            ensureGeolocationService().handle(request: request)
+        }
+    }
+    
+    // MARK: - Geolocation
+    
+    private func ensureGeolocationService() -> GeolocationService {
+        if let service = geolocationService { return service }
+        let service = GeolocationService { [weak self] jsResponse in
+            Task {
+                await self?.respondToJSWithGeolocation(response: jsResponse)
+            }
+        }
+        geolocationService = service
+        return service
+    }
+
+    private func respondToJSWithGeolocation(response: JSRespondable) async {
+        do {
+            _ = try await webView.callAsyncJavaScript(
+                "window.__kiwixGeolocationResolve(payload);",
+                arguments: ["payload": response.jsResponse],
+                in: nil,
+                contentWorld: .page
+            )
+        } catch let error as NSError where error.domain == WKError.errorDomain
+            && (error.code == WKError.webContentProcessTerminated.rawValue
+                || error.code == WKError.webViewInvalidated.rawValue) {
+            // Page is gone — expected during teardown, no signal worth keeping.
+        } catch {
+            let message = error.localizedDescription
+            Log.Geolocation.error(
+                "respondToJSWithGeolocation failed: \(message, privacy: .public)"
+            )
         }
     }
 

--- a/project.yml
+++ b/project.yml
@@ -24,6 +24,8 @@ settings:
     INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone: UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight
     INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad: UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight
     INFOPLIST_KEY_NSPhotoLibraryUsageDescription: "Kiwix needs permission to saves images to your photos app."
+    INFOPLIST_KEY_NSLocationWhenInUseUsageDescription: "Kiwix can share your location with map content from ZIM files you open."
+    INFOPLIST_KEY_NSLocationUsageDescription: "Kiwix can share your location with map content from ZIM files you open."
     INFOPLIST_KEY_LSSupportsOpeningDocumentsInPlace: YES
     INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents: YES
     SWIFT_OBJC_INTEROP_MODE: objcxx
@@ -67,6 +69,7 @@ targetTemplates:
         com.apple.security.network.client: true
         com.apple.security.network.server: true
         com.apple.security.print: true
+        com.apple.security.personal-information.location: true
     dependencies:
       - framework: CoreKiwix.xcframework
         embed: false


### PR DESCRIPTION
Fixes: #1560 

It needed conceptual changes compared to: #1554 

In short there are multiple web "components" that could require location, either "watching" or one time request.

In the original was adding an ID to each of these requests, and that was creating multiple tasks for each of those requests, and accordingly responses as well.

This is not needed, we can gather the requests on both sides, the JS needs to store the return functions (success, error), while the swift sides only need to know the ids of those requests. If there are no more requests we can stop, if there are new ones we can start the location manager.
Once we do receive a location, we can send the response back to JS, and that can "distribute" it to all stored success functions. The error returns are done in the same way.

Also the location updates might not come that often (especially if we are not moving), so we can cache the last known location and return that immediately.

# iPhone
https://github.com/user-attachments/assets/8eb3278e-a72f-49b4-922b-a9bc55473f80

# mac
https://github.com/user-attachments/assets/844c6391-b4c7-494d-a151-5327a8dcca1e






