### PR TITLE
Update release/nightly/ci uploads for new destination

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -223,18 +223,18 @@ jobs:
     - name: Write SSH private key (to upload packages) to filesystem
       if: matrix.destination == 'ftp' && contains(env.UPLOAD_TO, matrix.destination)
       run: |
-        echo "${{ secrets.KIWIX_FILE_UPLOAD_SSH_KEY }}" > $KIWIX_FILE_UPLOAD_SSH_KEY_PATH
+        echo "${{ secrets.KIWIXAPPLE_FILE_UPLOAD_KEY }}" > $KIWIX_FILE_UPLOAD_SSH_KEY_PATH
         chmod 600 $KIWIX_FILE_UPLOAD_SSH_KEY_PATH
 
     - name: Upload DMG
       if: matrix.platform == 'macOS' && matrix.destination == 'ftp' && contains(env.UPLOAD_TO, matrix.destination)
       run: |
         mv ${PWD}/kiwix-${VERSION}.dmg ${PWD}/kiwix-macos_${VERSION}.dmg
-        python .github/upload_file.py --src ${PWD}/kiwix-macos_${VERSION}.dmg --dest ci@master.download.kiwix.org:30022/data/download/${UPLOAD_FOLDER} --ssh-key ${KIWIX_FILE_UPLOAD_SSH_KEY_PATH}
+        python .github/upload_file.py --src ${PWD}/kiwix-macos_${VERSION}.dmg --dest kiwix-apple@master.download.kiwix.org:30322/data/kiwix/${UPLOAD_FOLDER} --ssh-key ${KIWIX_FILE_UPLOAD_SSH_KEY_PATH}
         mv ${PWD}/kiwix-macos_${VERSION}.dmg ${PWD}/kiwix-${VERSION}.dmg
 
     - name: Upload IPA
       if: matrix.platform == 'iOS' && matrix.destination == 'ftp' && contains(env.UPLOAD_TO, matrix.destination)
       run: |
         mv ${PWD}/export/Kiwix.ipa ${PWD}/export/kiwix-${VERSION}.ipa
-        python .github/upload_file.py --src ${PWD}/export/kiwix-${VERSION}.ipa --dest ci@master.download.kiwix.org:30022/data/download/${UPLOAD_FOLDER} --ssh-key ${KIWIX_FILE_UPLOAD_SSH_KEY_PATH}
+        python .github/upload_file.py --src ${PWD}/export/kiwix-${VERSION}.ipa --dest kiwix-apple@master.download.kiwix.org:30322/data/kiwix/${UPLOAD_FOLDER} --ssh-key ${KIWIX_FILE_UPLOAD_SSH_KEY_PATH}


### PR DESCRIPTION
As part of a server/infra change, the upload of nightly and release builds is done to a new destination.

The receiving service now uses per-project (well per-repo) users with independent SSH Keys. Each users now only has access to the folders in which it is expected to upload files.

- Host remains the same: `master.download.kiwix.org`
- Username changes from `ci` to `kiwix-apple`
- Port changes from `30022` to `30322`
- Path prefix changed from `/data/download` to `/data/kiwix`

Secret has been created.

Fixes #1566 