### PR TITLE
1032 recurring payments with apple pay email

### DIFF
--- a/App/App_macOS.swift
+++ b/App/App_macOS.swift
@@ -147,16 +147,22 @@ struct Kiwix: App {
         Window(LocalString.payment_donate_title, id: "donation") {
             Group {
                 if let selectedAmount {
-                    PaymentSummary(selectedAmount: selectedAmount, onComplete: {
-                        closeDonation()
-                        switch Payment.showResult() {
-                        case .none: break
+                    PaymentSummary(selectedAmount: selectedAmount)
+                    .onReceive(NotificationCenter.default.publisher(for: .donationResult)) { notification in
+                        guard let finalResult = notification.userInfo?["result"] as? Payment.FinalResult else {
+                            return
+                        }
+                        switch finalResult {
                         case .thankYou:
                             openWindow(id: "donation-thank-you")
                         case .error:
                             openWindow(id: "donation-error")
+                        case .dismiss:
+                            closeDonation()
+                        case .errorAlreadyHasSubscription:
+                            openWindow(id: "donation-error-already-has-subscription")
                         }
-                    })
+                    }
                 } else {
                     PaymentForm(amountSelected: amountSelected)
                         .frame(width: 320, height: 320)
@@ -193,6 +199,16 @@ struct Kiwix: App {
 
         Window("", id: "donation-error") {
             PaymentResultPopUp(state: .error)
+                .padding()
+        }
+        .windowResizability(.contentMinSize)
+        .commandsRemoved()
+        .defaultSize(width: 320, height: 198)
+        .restorationBehaviourDisabled()
+        .handlesExternalEvents(matching: [])
+        
+        Window("", id: "donation-error-already-has-subscription") {
+            PaymentResultPopUp(state: .errorAlreadyHasSubscription)
                 .padding()
         }
         .windowResizability(.contentMinSize)

--- a/App/App_macOS.swift
+++ b/App/App_macOS.swift
@@ -13,11 +13,11 @@
 // You should have received a copy of the GNU General Public License
 // along with Kiwix; If not, see https://www.gnu.org/licenses/.
 
+import Combine
+import CoreKiwix
+import Defaults
 import SwiftUI
 import UserNotifications
-import Combine
-import Defaults
-import CoreKiwix
 
 #if os(macOS)
 final class AppDelegate: NSObject, NSApplicationDelegate {
@@ -203,10 +203,10 @@ struct Kiwix: App {
     }
 
     private func closeDonation() {
-        // after upgrading to macOS 14, use:
+        // even after upgrading to macOS 14 with
         // @Environment(\.dismissWindow) var dismissWindow
-        // and call:
-        // dismissWindow(id: "donation")
+        // and calling: dismissWindow(id: "donation")
+        // it is still not working as expected
         NSApplication.shared.windows.first { window in
             window.identifier?.rawValue == "donation"
         }?.close()

--- a/Model/Payment.swift
+++ b/Model/Payment.swift
@@ -175,6 +175,7 @@ struct Payment {
         return request
     }
 
+    // swiftlint:disable:next function_body_length
     func onPaymentAuthPhase(selectedAmount: SelectedAmount,
                             phase: PayWithApplePayButtonPaymentAuthorizationPhase) {
         switch phase {

--- a/Model/Payment.swift
+++ b/Model/Payment.swift
@@ -67,7 +67,7 @@ struct Payment {
     // optional to be implemented:
     // for reference see:
     // https://developer.apple.com/documentation/merchanttokennotificationservices
-    static let paymentSubscriptionTokenCallbackURL = URL(string: "http://api.donation.kiwix.org/v1/stripe/token-callback")!
+    static let subscriptionTokenCallbackURL = URL(string: "http://api.donation.kiwix.org/v1/stripe/token-callback")!
     static let supportedNetworks: [PKPaymentNetwork] = [
         .amex,
         PKPaymentNetwork.pagoBancomat,
@@ -253,7 +253,7 @@ struct Payment {
             managementURL: URL(string: Self.paymentSubscriptionManagingURL)!
         )
         payRequest.regularBilling.intervalUnit = .month
-        payRequest.tokenNotificationURL = Self.paymentSubscriptionTokenCallbackURL
+        payRequest.tokenNotificationURL = Self.subscriptionTokenCallbackURL
         return payRequest
     }
 

--- a/Model/Payment.swift
+++ b/Model/Payment.swift
@@ -207,7 +207,11 @@ struct Payment {
                                                    returnURLPath: nil,
                                                    usingClientSecretProvider: { @Sendable in
                     await StripeKiwix
-                        .clientSecretForPayment(endPoint: endPoint, selectedAmount: selectedAmount, email: email)
+                        .clientSecretForPayment(endPoint: endPoint,
+                                                selectedAmount: selectedAmount,
+                                                email: email,
+                                                deviceName: Device.current.rawValue
+                        )
                 }, withAPI: StripeAsyncAPI())
 
                 switch result.status {

--- a/Model/Payment.swift
+++ b/Model/Payment.swift
@@ -190,6 +190,9 @@ struct Payment {
             Log.Payment.info("onPaymentAuthPhase: .didAuthorize")
             // call our server to get payment / setup intent and return the client.secret
             Task { @MainActor [resultHandler] in
+                let emailAddress = payment.shippingContact!.emailAddress!
+                Log.Payment.info("Email? \(emailAddress)")
+                // let paymentServer = StripeKiwix(endPoint: URL(string: "http://localhost:8000/v1/stripe")!)
                 let paymentServer = StripeKiwix(endPoint: Self.kiwixPaymentServer)
                 do {
                     let publicKey = try await paymentServer.publishableKey()
@@ -208,7 +211,8 @@ struct Payment {
                 let result = await stripe.complete(payment: payment,
                                                    returnURLPath: nil,
                                                    usingClientSecretProvider: { @Sendable in
-                    await StripeKiwix.clientSecretForPayment(endPoint: endPoint, selectedAmount: selectedAmount)
+                    await StripeKiwix
+                        .clientSecretForPayment(endPoint: endPoint, selectedAmount: selectedAmount, email: emailAddress)
                 }, withAPI: StripeAsyncAPI())
                 // calling any UI refreshing state / subject from here
                 // will block the UI in the payment state forever

--- a/Model/Payment.swift
+++ b/Model/Payment.swift
@@ -60,14 +60,19 @@ struct Payment {
 
     let completeSubject = PassthroughSubject<Void, Never>()
 
+    #if DEBUG
+    static let kiwixPaymentServer = URL(string: "https://staging.api.donation.kiwix.org/v1/stripe")!
+    static let subscriptionTokenCallbackURL = URL(string: "http://staging.api.donation.kiwix.org/v1/stripe/token-callback")!
+    #else
     static let kiwixPaymentServer = URL(string: "https://api.donation.kiwix.org/v1/stripe")!
+    static let subscriptionTokenCallbackURL = URL(string: "http://api.donation.kiwix.org/v1/stripe/token-callback")!
+    #endif
     static let merchantSessionURL = URL(string: "https://apple-pay-gateway.apple.com" )!
     static let merchantId = "merchant.org.kiwix.apple"
     static let paymentSubscriptionManagingURL = "https://www.kiwix.org"
     // optional to be implemented:
     // for reference see:
     // https://developer.apple.com/documentation/merchanttokennotificationservices
-    static let subscriptionTokenCallbackURL = URL(string: "http://api.donation.kiwix.org/v1/stripe/token-callback")!
     static let supportedNetworks: [PKPaymentNetwork] = [
         .amex,
         PKPaymentNetwork.pagoBancomat,
@@ -190,8 +195,6 @@ struct Payment {
             Log.Payment.info("onPaymentAuthPhase: .didAuthorize")
             // call our server to get payment / setup intent and return the client.secret
             Task { @MainActor [resultHandler] in
-                let emailAddress = payment.shippingContact!.emailAddress!
-                Log.Payment.info("Email? \(emailAddress)")
                 // let paymentServer = StripeKiwix(endPoint: URL(string: "http://localhost:8000/v1/stripe")!)
                 let paymentServer = StripeKiwix(endPoint: Self.kiwixPaymentServer)
                 do {
@@ -208,11 +211,12 @@ struct Payment {
                 // This should probably be a URL that opens your iOS app."
                 let stripe = StripeApplePaySimple()
                 let endPoint = paymentServer.endPoint
+                let email = payment.shippingContact?.emailAddress ?? ""
                 let result = await stripe.complete(payment: payment,
                                                    returnURLPath: nil,
                                                    usingClientSecretProvider: { @Sendable in
                     await StripeKiwix
-                        .clientSecretForPayment(endPoint: endPoint, selectedAmount: selectedAmount, email: emailAddress)
+                        .clientSecretForPayment(endPoint: endPoint, selectedAmount: selectedAmount, email: email)
                 }, withAPI: StripeAsyncAPI())
                 // calling any UI refreshing state / subject from here
                 // will block the UI in the payment state forever

--- a/Model/Payment.swift
+++ b/Model/Payment.swift
@@ -64,6 +64,8 @@ struct Payment {
     static let merchantSessionURL = URL(string: "https://apple-pay-gateway.apple.com" )!
     static let merchantId = "merchant.org.kiwix.apple"
     static let paymentSubscriptionManagingURL = "https://www.kiwix.org"
+    // TODO: verify if we need this
+//    static let paymentSubscriptionTokenCallbackURL = URL(string: "http://192.168.100.50:4242/token")!
     static let supportedNetworks: [PKPaymentNetwork] = [
         .amex,
         PKPaymentNetwork.pagoBancomat,
@@ -165,28 +167,15 @@ struct Payment {
     func donationRequest(for selectedAmount: SelectedAmount) -> PKPaymentRequest {
         let request = PKPaymentRequest()
         request.merchantIdentifier = Self.merchantId
-        request.merchantCapabilities = Self.capabilities
-        request.countryCode = "CH"
+        request.countryCode = Locale.Region.switzerland.identifier
         request.currencyCode = selectedAmount.currency
         request.supportedNetworks = Self.supportedNetworks
+        request.merchantCapabilities = Self.capabilities
+        // We have to require the shipping email, otherwise we don't get any email at all!
+        request.requiredShippingContactFields = [.emailAddress]
         request.requiredBillingContactFields = [.emailAddress]
-        let recurring: PKRecurringPaymentRequest? = if selectedAmount.isMonthly {
-            PKRecurringPaymentRequest(paymentDescription: LocalString.payment_description_label,
-                                      regularBilling: .init(label: LocalString.payment_monthly_support_label,
-                                                            amount: NSDecimalNumber(value: selectedAmount.value),
-                                                            type: .final),
-                                      managementURL: URL(string: Self.paymentSubscriptionManagingURL)!)
-        } else {
-            nil
-        }
-        request.recurringPaymentRequest = recurring
-        request.paymentSummaryItems = [
-            PKPaymentSummaryItem(
-                label: LocalString.payment_summary_title,
-                amount: NSDecimalNumber(value: selectedAmount.value),
-                type: .final
-            )
-        ]
+        request.recurringPaymentRequest = recurringPayment(for: selectedAmount)
+        request.paymentSummaryItems = summartItems(for: selectedAmount)
         return request
     }
 
@@ -246,6 +235,41 @@ struct Payment {
             return .init(status: .failure, merchantSession: nil)
         }
         return .init(status: .success, merchantSession: session)
+    }
+
+    private func recurringPayment(for selectedAmount: SelectedAmount) -> PKRecurringPaymentRequest? {
+        guard selectedAmount.isMonthly else { return nil }
+        let payRequest = PKRecurringPaymentRequest(
+            paymentDescription: LocalString.payment_description_label,
+            regularBilling: .init(
+                label: LocalString.payment_monthly_support_label,
+                amount: NSDecimalNumber(value: selectedAmount.value),
+                type: .final
+            ),
+            managementURL: URL(string: Self.paymentSubscriptionManagingURL)!
+        )
+        payRequest.regularBilling.intervalUnit = .month
+        // not yet sure how this is used, or if needed
+//        payRequest.tokenNotificationURL = Self.paymentSubscriptionTokenCallbackURL
+        return payRequest
+    }
+
+    private func summartItems(for selectedAmount: SelectedAmount) -> [PKPaymentSummaryItem] {
+        let item: PKPaymentSummaryItem
+        if selectedAmount.isMonthly {
+            let recurringItem = PKRecurringPaymentSummaryItem(label: LocalString.payment_monthly_support_label,
+                                                 amount: NSDecimalNumber(value: selectedAmount.value),
+                                                 type: .final)
+            recurringItem.startDate = Date() // starts now
+            recurringItem.intervalUnit = .month
+            recurringItem.endDate = nil // never ending
+            item = recurringItem
+        } else {
+            item = PKPaymentSummaryItem(label: LocalString.payment_summary_title,
+                                        amount: NSDecimalNumber(value: selectedAmount.value),
+                                        type: .final)
+        }
+        return [item]
     }
 }
 

--- a/Model/Payment.swift
+++ b/Model/Payment.swift
@@ -41,7 +41,7 @@ import os
 /// https://github.com/CodeLikeW/stripe-core
 struct Payment {
 
-    enum FinalResult: String {
+    enum FinalResult {
         case thankYou
         case error
         case errorAlreadyHasSubscription
@@ -180,6 +180,9 @@ struct Payment {
         switch phase {
         case .willAuthorize:
             Log.Payment.info("onPaymentAuthPhase: .willAuthorize")
+        // Important! do not attempt to do anything UI related after
+        // the resultHandler is called, it will block the Apple Pay pop-up
+        // and only background / foreground-ing the app will unblock it
         case .didAuthorize(let payment, let resultHandler):
             Log.Payment.info("onPaymentAuthPhase: .didAuthorize")
             // call our server to get payment / setup intent and return the client.secret

--- a/Model/Payment.swift
+++ b/Model/Payment.swift
@@ -64,8 +64,10 @@ struct Payment {
     static let merchantSessionURL = URL(string: "https://apple-pay-gateway.apple.com" )!
     static let merchantId = "merchant.org.kiwix.apple"
     static let paymentSubscriptionManagingURL = "https://www.kiwix.org"
-    // TODO: verify if we need this
-//    static let paymentSubscriptionTokenCallbackURL = URL(string: "http://192.168.100.50:4242/token")!
+    // optional to be implemented:
+    // for reference see:
+    // https://developer.apple.com/documentation/merchanttokennotificationservices
+    static let paymentSubscriptionTokenCallbackURL = URL(string: "http://api.donation.kiwix.org/v1/stripe/token-callback")!
     static let supportedNetworks: [PKPaymentNetwork] = [
         .amex,
         PKPaymentNetwork.pagoBancomat,
@@ -197,8 +199,10 @@ struct Payment {
                     resultHandler(.init(status: .failure, errors: [serverError]))
                     return
                 }
-                // we should update the return path for confirmations
-                // see: https://github.com/kiwix/kiwix-apple/issues/1032
+                // Note: the returnURL path is not needed, we are never leaving the app. According to stripe docs:
+                // "The URL to redirect your customer back to after they authenticate or cancel
+                // their payment on the payment method’s app or site.
+                // This should probably be a URL that opens your iOS app."
                 let stripe = StripeApplePaySimple()
                 let endPoint = paymentServer.endPoint
                 let result = await stripe.complete(payment: payment,
@@ -249,8 +253,7 @@ struct Payment {
             managementURL: URL(string: Self.paymentSubscriptionManagingURL)!
         )
         payRequest.regularBilling.intervalUnit = .month
-        // not yet sure how this is used, or if needed
-//        payRequest.tokenNotificationURL = Self.paymentSubscriptionTokenCallbackURL
+        payRequest.tokenNotificationURL = Self.paymentSubscriptionTokenCallbackURL
         return payRequest
     }
 

--- a/Model/Payment.swift
+++ b/Model/Payment.swift
@@ -41,27 +41,16 @@ import os
 /// https://github.com/CodeLikeW/stripe-core
 struct Payment {
 
-    enum FinalResult {
+    enum FinalResult: String {
         case thankYou
         case error
+        case errorAlreadyHasSubscription
+        case dismiss
     }
-
-    /// Decides if the Thank You / Error pop up should be shown
-    /// - Returns: `FinalResult` only once
-    @MainActor
-    static func showResult() -> FinalResult? {
-        // make sure `true` is "read only once"
-        let value = Self.finalResult
-        Self.finalResult = nil
-        return value
-    }
-    @MainActor
-    static private var finalResult: Payment.FinalResult?
-
-    let completeSubject = PassthroughSubject<Void, Never>()
 
     #if DEBUG
     static let kiwixPaymentServer = URL(string: "https://staging.api.donation.kiwix.org/v1/stripe")!
+    // swiftlint:disable:next line_length
     static let subscriptionTokenCallbackURL = URL(string: "http://staging.api.donation.kiwix.org/v1/stripe/token-callback")!
     #else
     static let kiwixPaymentServer = URL(string: "https://api.donation.kiwix.org/v1/stripe")!
@@ -195,13 +184,12 @@ struct Payment {
             Log.Payment.info("onPaymentAuthPhase: .didAuthorize")
             // call our server to get payment / setup intent and return the client.secret
             Task { @MainActor [resultHandler] in
-                // let paymentServer = StripeKiwix(endPoint: URL(string: "http://localhost:8000/v1/stripe")!)
                 let paymentServer = StripeKiwix(endPoint: Self.kiwixPaymentServer)
                 do {
                     let publicKey = try await paymentServer.publishableKey()
                     StripeAPI.setDefault(publishableKey: publicKey)
                 } catch let serverError {
-                    Self.finalResult = .error
+                    NotificationCenter.donationResult(.error)
                     resultHandler(.init(status: .failure, errors: [serverError]))
                     return
                 }
@@ -218,23 +206,27 @@ struct Payment {
                     await StripeKiwix
                         .clientSecretForPayment(endPoint: endPoint, selectedAmount: selectedAmount, email: email)
                 }, withAPI: StripeAsyncAPI())
-                // calling any UI refreshing state / subject from here
-                // will block the UI in the payment state forever
-                // therefore it's defered via static finalResult
+
                 switch result.status {
                 case .success:
-                    Self.finalResult = .thankYou
+                    NotificationCenter.donationResult(.thankYou)
                 case .failure:
-                    Self.finalResult = .error
+                    if let firstError = result.errors.first as? NSError,
+                       firstError.domain == "Kiwix.StripeKiwix.StripeError",
+                       firstError.code == StripeKiwix.StripeError.errorAlreadyHasSubscription.rawValue {
+                        NotificationCenter.donationResult(.errorAlreadyHasSubscription)
+                    } else {
+                        NotificationCenter.donationResult(.error)
+                    }
                 default:
-                    Self.finalResult = nil
+                    NotificationCenter.donationResult(.error)
                 }
-                resultHandler(result)
                 Log.Payment.info("onPaymentAuthPhase: .didAuthorize: \(result.status == .success, privacy: .public)")
+                resultHandler(result)
             }
         case .didFinish:
             Log.Payment.info("onPaymentAuthPhase: .didFinish")
-            completeSubject.send(())
+            NotificationCenter.donationResult(.dismiss)
         @unknown default:
             Log.Payment.error("onPaymentAuthPhase: @unknown default")
         }
@@ -243,7 +235,7 @@ struct Payment {
     @MainActor
     func onMerchantSessionUpdate() async -> PKPaymentRequestMerchantSessionUpdate {
         guard let session = await StripeKiwix.stripeSession(endPoint: Self.kiwixPaymentServer) else {
-            Self.finalResult = .error
+            NotificationCenter.donationResult(.error)
             return .init(status: .failure, merchantSession: nil)
         }
         return .init(status: .success, merchantSession: session)

--- a/Model/StripeKiwix.swift
+++ b/Model/StripeKiwix.swift
@@ -49,7 +49,8 @@ struct StripeKiwix {
     nonisolated static func clientSecretForPayment(
         endPoint: URL,
         selectedAmount: SelectedAmount,
-        email: String
+        email: String,
+        deviceName: String
     ) async -> Result<String, Error> {
         do {
             let requestPath = selectedAmount.isMonthly ? "setup-intent" : "payment-intent"
@@ -57,7 +58,9 @@ struct StripeKiwix {
             request.httpMethod = "POST"
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
             request.httpBody = try JSONEncoder()
-                .encode(SelectedPaymentAmount(from: selectedAmount, emailAddress: email))
+                .encode(SelectedPaymentAmount(from: selectedAmount,
+                                              emailAddress: email,
+                                              deviceName: deviceName))
             let (data, response) = try await URLSession.shared.data(for: request)
             guard let httpResponse = response as? HTTPURLResponse else {
                 throw StripeError.serverError
@@ -117,8 +120,14 @@ private struct SelectedPaymentAmount: Encodable {
     let amount: Int
     let currency: String
     let email: String
+    let device: String
+    #if os(macOS)
+    let locale: String = NSLocale.preferredLanguages.first ?? ""
+    #else
+    let locale: String = Locale.preferredLanguages.first ?? ""
+    #endif
 
-    init(from selectedAmount: SelectedAmount, emailAddress: String) {
+    init(from selectedAmount: SelectedAmount, emailAddress: String, deviceName: String) {
         // Amount intended to be collected by this PaymentIntent.
         // A positive integer representing how much to charge in the smallest currency unit
         // (e.g., 100 cents to charge $1.00 or 100 to charge ¥100, a zero-decimal currency).
@@ -126,6 +135,7 @@ private struct SelectedPaymentAmount: Encodable {
         amount = Int(selectedAmount.value * 100.0)
         currency = selectedAmount.currency
         assert(Payment.currencyCodes.contains(currency))
+        device = deviceName
         email = emailAddress
     }
 }

--- a/Model/StripeKiwix.swift
+++ b/Model/StripeKiwix.swift
@@ -44,7 +44,7 @@ struct StripeKiwix {
     nonisolated static func clientSecretForPayment(
         endPoint: URL,
         selectedAmount: SelectedAmount,
-        email: String?
+        email: String
     ) async -> Result<String, Error> {
         do {
             let requestPath = selectedAmount.isMonthly ? "setup-intent" : "payment-intent"
@@ -105,9 +105,9 @@ private struct ClientSecretKey: Decodable {
 private struct SelectedPaymentAmount: Encodable {
     let amount: Int
     let currency: String
-    let email: String?
+    let email: String
 
-    init(from selectedAmount: SelectedAmount, emailAddress: String?) {
+    init(from selectedAmount: SelectedAmount, emailAddress: String) {
         // Amount intended to be collected by this PaymentIntent.
         // A positive integer representing how much to charge in the smallest currency unit
         // (e.g., 100 cents to charge $1.00 or 100 to charge ¥100, a zero-decimal currency).

--- a/Model/StripeKiwix.swift
+++ b/Model/StripeKiwix.swift
@@ -46,9 +46,8 @@ struct StripeKiwix {
         selectedAmount: SelectedAmount
     ) async -> Result<String, Error> {
         do {
-            // for monthly we should create a setup-intent:
-            // see: https://github.com/kiwix/kiwix-apple/issues/1032
-            var request = URLRequest(url: endPoint.appending(path: "payment-intent"))
+            let requestPath = selectedAmount.isMonthly ? "setup-intent" : "payment-intent"
+            var request = URLRequest(url: endPoint.appending(path: requestPath))
             request.httpMethod = "POST"
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
             request.httpBody = try JSONEncoder().encode(SelectedPaymentAmount(from: selectedAmount))

--- a/Model/StripeKiwix.swift
+++ b/Model/StripeKiwix.swift
@@ -120,12 +120,8 @@ private struct SelectedPaymentAmount: Encodable {
     let amount: Int
     let currency: String
     let email: String
-    let device: String
-    #if os(macOS)
-    let locale: String = NSLocale.preferredLanguages.first ?? ""
-    #else
-    let locale: String = Locale.preferredLanguages.first ?? ""
-    #endif
+    let origin: String
+    let lang: String = Locale.current.language.languageCode?.identifier ?? ""
 
     init(from selectedAmount: SelectedAmount, emailAddress: String, deviceName: String) {
         // Amount intended to be collected by this PaymentIntent.
@@ -135,7 +131,7 @@ private struct SelectedPaymentAmount: Encodable {
         amount = Int(selectedAmount.value * 100.0)
         currency = selectedAmount.currency
         assert(Payment.currencyCodes.contains(currency))
-        device = deviceName
+        origin = deviceName
         email = emailAddress
     }
 }

--- a/Model/StripeKiwix.swift
+++ b/Model/StripeKiwix.swift
@@ -43,14 +43,16 @@ struct StripeKiwix {
 
     nonisolated static func clientSecretForPayment(
         endPoint: URL,
-        selectedAmount: SelectedAmount
+        selectedAmount: SelectedAmount,
+        email: String?
     ) async -> Result<String, Error> {
         do {
             let requestPath = selectedAmount.isMonthly ? "setup-intent" : "payment-intent"
             var request = URLRequest(url: endPoint.appending(path: requestPath))
             request.httpMethod = "POST"
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-            request.httpBody = try JSONEncoder().encode(SelectedPaymentAmount(from: selectedAmount))
+            request.httpBody = try JSONEncoder()
+                .encode(SelectedPaymentAmount(from: selectedAmount, emailAddress: email))
             let (data, response) = try await URLSession.shared.data(for: request)
             guard let httpResponse = response as? HTTPURLResponse,
                   (200..<300).contains(httpResponse.statusCode) else {
@@ -103,8 +105,9 @@ private struct ClientSecretKey: Decodable {
 private struct SelectedPaymentAmount: Encodable {
     let amount: Int
     let currency: String
+    let email: String?
 
-    init(from selectedAmount: SelectedAmount) {
+    init(from selectedAmount: SelectedAmount, emailAddress: String?) {
         // Amount intended to be collected by this PaymentIntent.
         // A positive integer representing how much to charge in the smallest currency unit
         // (e.g., 100 cents to charge $1.00 or 100 to charge ¥100, a zero-decimal currency).
@@ -112,6 +115,7 @@ private struct SelectedPaymentAmount: Encodable {
         amount = Int(selectedAmount.value * 100.0)
         currency = selectedAmount.currency
         assert(Payment.currencyCodes.contains(currency))
+        email = emailAddress
     }
 }
 private struct SessionParams: Encodable {

--- a/Model/StripeKiwix.swift
+++ b/Model/StripeKiwix.swift
@@ -23,8 +23,9 @@ struct StripeKiwix {
     /// see: https://docs.stripe.com/api/payment_intents/object#payment_intent_object-amount
     static let maxAmount: Int = 999999999
 
-    enum StripeError: Error {
+    enum StripeError: Int, Error {
         case serverError
+        case errorAlreadyHasSubscription
     }
 
     let endPoint: URL
@@ -40,6 +41,10 @@ struct StripeKiwix {
         let json = try decoder.decode(PublishableKey.self, from: data)
         return json.publishableKey
     }
+    
+    private struct ErrorData: Decodable {
+        let detail: String
+    }
 
     nonisolated static func clientSecretForPayment(
         endPoint: URL,
@@ -54,9 +59,15 @@ struct StripeKiwix {
             request.httpBody = try JSONEncoder()
                 .encode(SelectedPaymentAmount(from: selectedAmount, emailAddress: email))
             let (data, response) = try await URLSession.shared.data(for: request)
-            guard let httpResponse = response as? HTTPURLResponse,
-                  (200..<300).contains(httpResponse.statusCode) else {
+            guard let httpResponse = response as? HTTPURLResponse else {
                 throw StripeError.serverError
+            }
+            guard (200..<300).contains(httpResponse.statusCode) else {
+                if httpResponse.statusCode == 409 {
+                        throw StripeError.errorAlreadyHasSubscription
+                } else {
+                    throw StripeError.serverError
+                }
             }
             let json = try JSONDecoder().decode(ClientSecretKey.self, from: data)
             return .success(json.secret)

--- a/Support/en.lproj/Localizable.strings
+++ b/Support/en.lproj/Localizable.strings
@@ -335,6 +335,8 @@
 "payment.success.description" = "Your generosity means everything to us.";
 "payment.error.title" = "Well that's awkward.";
 "payment.error.description" = "There has been an issue with your payment. Please try again.";
+"payment.error_already_subscribed.title" = "You already have a monthly donation";
+"payment.error_already_subscribed.description" = "Use the instructions in the email we sent earlier to update it.";
 "download_service.error.client.backgroundSessionInUseByAnotherProcess" = "Could not communicate with background transfer service";
 "download_service.error.client.backgroundSessionWasDisconnected" = "Lost connection to background transfer service";
 "download_service.error.client.cancelled" = "cancelled";

--- a/Support/qqq.lproj/Localizable.strings
+++ b/Support/qqq.lproj/Localizable.strings
@@ -287,6 +287,8 @@
 "payment.success.description" = "Confirmation text that the donation payment was successful and thanking the user for supporting us";
 "payment.error.title" = "Error message title, the user receives if the payment fails";
 "payment.error.description" = "Error message description, the user receives if the payment fails";
+"payment.error_already_subscribed.title" = "Error message title, when the user tries to subscribe to a monthly subscription, but an existing subscription is already in place, based on the email address provided.";
+"payment.error_already_subscribed.description" = "Error message description, under the title, explaining that the existing suscription can only be changed externally to the application, using the instructions in the email sent earlier.";
 "download_service.error.client.backgroundSessionInUseByAnotherProcess" = "Additional description of the download alert pop up, describing the specific system error, that occured.";
 "download_service.error.client.backgroundSessionWasDisconnected" = "Additional description of the download alert pop up, describing the specific system error, that occured.";
 "download_service.error.client.cancelled" = "Additional description of the download alert pop up, describing the specific system error, that occured.";

--- a/SwiftUI/Patches.swift
+++ b/SwiftUI/Patches.swift
@@ -84,6 +84,7 @@ extension Notification.Name {
     #endif
     static let goBack = Notification.Name("goBack")
     static let goForward = Notification.Name("goForward")
+    static let donationResult = Notification.Name("donationResult")
     #if os(iOS)
     static let openDonations = Notification.Name("openDonations")
     static let hotspotShareURL = Notification.Name("hotspotShareURL")
@@ -149,6 +150,15 @@ extension NotificationCenter {
                                         userInfo: ["tabIds": tabIds])
     }
     #endif
+    
+    nonisolated static func donationResult(_ finalResult: Payment.FinalResult) {
+        Task.detached(priority: .utility) {
+            try await Task.sleep(nanoseconds: 2000)
+            await MainActor.run {
+                NotificationCenter.default.post(name: .donationResult, object: nil, userInfo: ["result": finalResult])
+            }
+        }
+    }
     
     #if os(iOS)
     @MainActor static func openDonations() {

--- a/Views/Payment/DonationViewModifier.swift
+++ b/Views/Payment/DonationViewModifier.swift
@@ -19,58 +19,56 @@ import Combine
 
 struct DonationViewModifier: ViewModifier {
     
-    enum DonationPopupState {
+    enum DonationPopup: Identifiable {
         case selection
         case selectedAmount(SelectedAmount)
         case thankYou
         case error
+        case errorAlreadyHasSubscription
+        
+        var id: String {
+            switch self {
+            case .selection: "selection"
+            case .selectedAmount: "selectedAmount"
+            case .thankYou: "thankYou"
+            case .error: "error"
+            case .errorAlreadyHasSubscription: "errorAlreadyHasSubscription"
+            }
+        }
     }
+    
     private let openDonations = NotificationCenter.default.publisher(for: .openDonations)
+    private let donationResult = NotificationCenter.default.publisher(for: .donationResult)
     private var amountSelected = PassthroughSubject<SelectedAmount?, Never>()
-    @State private var showDonationPopUp: Bool = false
-    @State private var donationPopUpState: DonationPopupState = .selection
+    @State private var donationPopup: DonationPopup?
     private let popupSize: PresentationDetent = if Device.current == .iPad { .fraction(0.83) } else { .fraction(0.65) }
     
-    // swiftlint:disable:next function_body_length
     func body(content: Content) -> some View {
         content
             .onReceive(openDonations) { _ in
-                showDonationPopUp = true
+                donationPopup = .selection
             }
-            .sheet(isPresented: $showDonationPopUp, onDismiss: {
-                let result = Payment.showResult()
-                switch result {
-                case .none:
+            .onReceive(donationResult) { notification in
+                guard let finalResult = notification.userInfo?["result"] as? Payment.FinalResult else {
                     // reset
-                    donationPopUpState = .selection
+                    donationPopup = nil
                     return
-                case .some(let finalResult):
-                    Task.detached(priority: .utility) {
-                        // we need to close the sheet in order to dismiss ApplePay,
-                        // and we need to re-open it again with a delay to show thank you state
-                        // Swift UI cannot yet handle multiple sheets
-                        try? await Task.sleep(for: .milliseconds(1000))
-                        await MainActor.run {
-                            switch finalResult {
-                            case .thankYou:
-                                donationPopUpState = .thankYou
-                            case .error:
-                                donationPopUpState = .error
-                            }
-                            showDonationPopUp = true
-                        }
-                    }
                 }
-            }, content: {
+                if finalResult != .dismiss {
+                    process(finalResult)
+                }
+            }
+            .sheet(item: $donationPopup, onDismiss: {
+                Log.Payment.debug("sheet onDismiss")
+            },
+            content: { item in
                 Group {
-                    switch donationPopUpState {
+                    switch item {
                     case .selection:
                         PaymentForm(amountSelected: amountSelected)
                             .presentationDetents([popupSize])
                     case .selectedAmount(let selectedAmount):
-                        PaymentSummary(selectedAmount: selectedAmount, onComplete: {
-                            showDonationPopUp = false
-                        })
+                        PaymentSummary(selectedAmount: selectedAmount)
                         .presentationDetents([popupSize])
                     case .thankYou:
                         PaymentResultPopUp(state: .thankYou)
@@ -78,18 +76,43 @@ struct DonationViewModifier: ViewModifier {
                     case .error:
                         PaymentResultPopUp(state: .error)
                             .presentationDetents([.fraction(0.33)])
+                    case .errorAlreadyHasSubscription:
+                        PaymentResultPopUp(state: .errorAlreadyHasSubscription)
+                            .presentationDetents([.fraction(0.33)])
                     }
                 }
                 .onReceive(amountSelected) { value in
                     if let amount = value {
-                        donationPopUpState = .selectedAmount(amount)
+                        donationPopup = .selectedAmount(amount)
                     } else {
-                        donationPopUpState = .selection
+                        donationPopup = .selection
                     }
                 }
                 // make sure payment sheet is not confusingly transparent on iPhone
                 .presentationBackground(Color(.secondarySystemBackground))
             })
+    }
+    
+    private func process(_ finalResult: Payment.FinalResult) {
+        guard finalResult != .dismiss else { return }
+        Log.Payment.debug("received finalResult: \(finalResult.rawValue)")
+        Task(priority: .utility) {
+            // we need to wait until ApplePay dismisses properly,
+            // and we need to re-open the sheet again with a delay to show thank you / error state
+            // Swift UI cannot yet handle multiple sheets
+            try? await Task.sleep(for: .milliseconds(2000))
+            switch finalResult {
+            case .thankYou:
+                donationPopup = .thankYou
+            case .error:
+                donationPopup = .error
+            case .errorAlreadyHasSubscription:
+                donationPopup = .errorAlreadyHasSubscription
+            case .dismiss:
+                break // do nothing
+            }
+        }
+        
     }
 }
 #endif

--- a/Views/Payment/DonationViewModifier.swift
+++ b/Views/Payment/DonationViewModifier.swift
@@ -88,7 +88,7 @@ struct DonationViewModifier: ViewModifier {
                     }
                 }
                 // make sure payment sheet is not confusingly transparent on iPhone
-                .presentationBackground(Color(.systemBackground))
+                .presentationBackground(Color(.secondarySystemBackground))
             })
     }
 }

--- a/Views/Payment/DonationViewModifier.swift
+++ b/Views/Payment/DonationViewModifier.swift
@@ -95,7 +95,6 @@ struct DonationViewModifier: ViewModifier {
     
     private func process(_ finalResult: Payment.FinalResult) {
         guard finalResult != .dismiss else { return }
-        Log.Payment.debug("received finalResult: \(finalResult.rawValue)")
         Task(priority: .utility) {
             // we need to wait until ApplePay dismisses properly,
             // and we need to re-open the sheet again with a delay to show thank you / error state

--- a/Views/Payment/DonationViewModifier.swift
+++ b/Views/Payment/DonationViewModifier.swift
@@ -29,6 +29,7 @@ struct DonationViewModifier: ViewModifier {
     private var amountSelected = PassthroughSubject<SelectedAmount?, Never>()
     @State private var showDonationPopUp: Bool = false
     @State private var donationPopUpState: DonationPopupState = .selection
+    private let popupSize: PresentationDetent = if Device.current == .iPad { .fraction(0.83) } else { .fraction(0.65) }
     
     // swiftlint:disable:next function_body_length
     func body(content: Content) -> some View {
@@ -65,12 +66,12 @@ struct DonationViewModifier: ViewModifier {
                     switch donationPopUpState {
                     case .selection:
                         PaymentForm(amountSelected: amountSelected)
-                            .presentationDetents([.fraction(0.65)])
+                            .presentationDetents([popupSize])
                     case .selectedAmount(let selectedAmount):
                         PaymentSummary(selectedAmount: selectedAmount, onComplete: {
                             showDonationPopUp = false
                         })
-                        .presentationDetents([.fraction(0.65)])
+                        .presentationDetents([popupSize])
                     case .thankYou:
                         PaymentResultPopUp(state: .thankYou)
                             .presentationDetents([.fraction(0.33)])

--- a/Views/Payment/DonationViewModifier.swift
+++ b/Views/Payment/DonationViewModifier.swift
@@ -86,6 +86,8 @@ struct DonationViewModifier: ViewModifier {
                         donationPopUpState = .selection
                     }
                 }
+                // make sure payment sheet is not confusingly transparent on iPhone
+                .presentationBackground(Color(.systemBackground))
             })
     }
 }

--- a/Views/Payment/PaymentForm.swift
+++ b/Views/Payment/PaymentForm.swift
@@ -20,20 +20,20 @@ struct PaymentForm: View {
     let amountSelected: PassthroughSubject<SelectedAmount?, Never>
     @State var isMonthly: Bool = false
     @Environment(\.dismiss) var dismiss
-    #if os(macOS)
+#if os(macOS)
     @EnvironmentObject var formReset: FormReset
-    #endif
-
+#endif
+    
     init(amountSelected: PassthroughSubject<SelectedAmount?, Never>) {
         self.amountSelected = amountSelected
     }
-
+    
     private func reset() {
         isMonthly = false
     }
-
+    
     var body: some View {
-        #if os(iOS)
+#if os(iOS)
         HStack {
             Spacer()
             Text(LocalString.payment_donate_title)
@@ -50,26 +50,31 @@ struct PaymentForm: View {
             .foregroundStyle(.tertiary)
             .padding()
         }
-        #endif
-
+#endif
+        
         VStack {
-            // Re-enable as part of: https://github.com/kiwix/kiwix-apple/issues/1032
-//            Picker("", selection: $isMonthly) {
-//                Label(LocalString.payment_selection_option_one_time, systemImage: "heart.circle").tag(false)
-//                Label(LocalString.payment_selection_option_monthly, systemImage: "arrow.clockwise.heart").tag(true)
-//            }.pickerStyle(.segmented)
-//                .padding([.leading, .trailing, .bottom])
-
+            Picker("", selection: $isMonthly) {
+                Label(
+                    LocalString.payment_selection_option_one_time,
+                    systemImage: "heart.circle"
+                )
+                .tag(false)
+                Label(
+                    LocalString.payment_selection_option_monthly,
+                    systemImage: "arrow.clockwise.heart"
+                )
+                .tag(true)
+            }.pickerStyle(.segmented)
+                .padding([.leading, .trailing, .bottom])
             ListOfAmounts(amountSelected: amountSelected, isMonthly: $isMonthly)
         }
-        #if os(macOS)
+#if os(macOS)
         .padding()
         .navigationTitle(LocalString.payment_donate_title)
         .onReceive(formReset.objectWillChange) { _ in
             reset()
         }
-        #endif
-
+#endif
     }
 }
 
@@ -81,7 +86,7 @@ struct SelectedAmount {
     let value: Double
     let currency: String
     let isMonthly: Bool
-
+    
     init(value: Double, currency: String, isMonthly: Bool) {
         // make sure we won't go over Stripe's max amount
         self.value = min(value, Double(StripeKiwix.maxAmount) * 100.0)
@@ -96,7 +101,7 @@ struct AmountOption: Identifiable {
     let id = UUID()
     let value: Double
     let isAverage: Bool
-
+    
     init(value: Double, isAverage: Bool = false) {
         self.value = value
         self.isAverage = isAverage

--- a/Views/Payment/PaymentResultPopUp.swift
+++ b/Views/Payment/PaymentResultPopUp.swift
@@ -28,6 +28,7 @@ struct PaymentResultPopUp: View {
     enum State {
         case thankYou
         case error
+        case errorAlreadyHasSubscription
     }
 
     var body: some View {
@@ -50,6 +51,11 @@ struct PaymentResultPopUp: View {
                     Text(LocalString.payment_error_title)
                         .font(.title)
                     Text(LocalString.payment_error_description)
+                        .font(.headline)
+                case .errorAlreadyHasSubscription:
+                    Text("It seems you already have a monthly donation.")
+                        .font(.title)
+                    Text("Please follow the email instructions sent earlier, to modify it.")
                         .font(.headline)
                 }
 

--- a/Views/Payment/PaymentResultPopUp.swift
+++ b/Views/Payment/PaymentResultPopUp.swift
@@ -53,12 +53,13 @@ struct PaymentResultPopUp: View {
                     Text(LocalString.payment_error_description)
                         .font(.headline)
                 case .errorAlreadyHasSubscription:
-                    Text("It seems you already have a monthly donation.")
+                    Text(
+                        LocalString.payment_error_already_subscribed_title)
                         .font(.title)
-                    Text("Please follow the email instructions sent earlier, to modify it.")
+                    Text(
+                        LocalString.payment_error_already_subscribed_description)
                         .font(.headline)
                 }
-
             }
             .multilineTextAlignment(.center)
         }

--- a/Views/Payment/PaymentSummary.swift
+++ b/Views/Payment/PaymentSummary.swift
@@ -23,14 +23,11 @@ struct PaymentSummary: View {
 
     private let selectedAmount: SelectedAmount
     private let payment: Payment
-    private let onComplete: @MainActor () -> Void
     @State private var paymentDetermined: Bool = false
     @State private var paymentButtonLabel: PayWithApplePayButtonLabel?
 
-    init(selectedAmount: SelectedAmount,
-         onComplete: @escaping @MainActor () -> Void) {
+    init(selectedAmount: SelectedAmount) {
         self.selectedAmount = selectedAmount
-        self.onComplete = onComplete
         payment = Payment()
     }
 
@@ -68,8 +65,6 @@ struct PaymentSummary: View {
             } else {
                 LoadingProgressView()
             }
-        }.onReceive(payment.completeSubject) {
-            onComplete()
         }
         .task {
             paymentButtonLabel = await Payment.paymentButtonTypeAsync()
@@ -82,7 +77,6 @@ struct PaymentSummary: View {
     PaymentSummary(
         selectedAmount: SelectedAmount(value: 34,
                                        currency: "CHF",
-                                       isMonthly: true),
-        onComplete: {}
+                                       isMonthly: true)
     )
 }

--- a/Views/Settings/Settings.swift
+++ b/Views/Settings/Settings.swift
@@ -165,6 +165,7 @@ struct Settings: View {
     @EnvironmentObject private var library: LibraryViewModel
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
     @State private var paymentButtonLabel: PayWithApplePayButtonLabel?
+    @Environment(\.dismiss) private var dismiss
 
     enum Route {
         case languageSelector, about
@@ -298,7 +299,11 @@ struct Settings: View {
     var miscellaneous: some View {
         Section(LocalString.settings_miscellaneous_title) {
             if paymentButtonLabel != nil, horizontalSizeClass != .regular {
+                // on iPhone
                 SupportKiwixButton {
+                    // need to dismiss settings first!
+                    dismiss()
+                    // as only 1 sheet can be presented at any given time
                     openDonation()
                 }
             }


### PR DESCRIPTION
Fixes: #1032 
Fixes: #1580

### Enables monthly subscriptions

### Adding the following to the payment requests:
- required email address via Apple Pay
- currently preferred user language
- current origin of the payment (mac, iphone, ipad)