### PR TITLE
Move location capability to Kiwix target only

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -69,7 +69,6 @@ targetTemplates:
         com.apple.security.network.client: true
         com.apple.security.network.server: true
         com.apple.security.print: true
-        com.apple.security.personal-information.location: true
     dependencies:
       - framework: CoreKiwix.xcframework
         embed: false
@@ -110,6 +109,7 @@ targets:
     entitlements:
       properties:
         com.apple.security.files.downloads.read-write: true
+        com.apple.security.personal-information.location: true
         com.apple.developer.in-app-payments: [merchant.org.kiwix.apple] # this line is removed for macOS FTP
     settings:
       base:


### PR DESCRIPTION
Fixes: https://github.com/kiwix/kiwix-apple-branded/issues/153

With this we are adding the location capability only to the Kiwix target, no branded app will have it.
If we will have some maps related branded app, we can revisit this, and do a per brand solution for this.