### PR TITLE
BrowserTab and content preloading for quicker switching

### DIFF
--- a/App/CompactViewController.swift
+++ b/App/CompactViewController.swift
@@ -13,16 +13,12 @@
 // You should have received a copy of the GNU General Public License
 // along with Kiwix; If not, see https://www.gnu.org/licenses/.
 
-//
-//  CompactViewController.swift
-//  Kiwix
-
 #if os(iOS)
 import Combine
-import SwiftUI
-import UIKit
 import CoreData
 import Defaults
+import SwiftUI
+import UIKit
 
 // iPhone portrait only
 struct CompactTabView: View {

--- a/App/SplitViewForiPad.swift
+++ b/App/SplitViewForiPad.swift
@@ -123,6 +123,9 @@ struct SplitViewForiPad: View { // swiftlint:disable:this type_body_length
             if let currentItem = navigation.currentItem {
                 selection = MenuItem(from: currentItem)
             }
+            if case let .tab(selectedTabId) = selection {
+                BrowserTabPreloader.shared.start(with: tabs, selectedTabId: selectedTabId)
+            }
         }
         .onChange(of: navigation.currentItem) { _, newValue in
             updateSelection(newValue)
@@ -290,10 +293,7 @@ struct SplitViewForiPad: View { // swiftlint:disable:this type_body_length
         if let newNavItem, let newSelection = MenuItem(from: newNavItem) {
             if selection != newSelection {
                 selection = newSelection
-                while !navPath.isEmpty {
-                    navPath.removeLast()
-                }
-                navPath.append(newSelection)
+                navPath = NavigationPath([newSelection])
             }
         }
     }

--- a/ViewModel/BrowserTabPreloader.swift
+++ b/ViewModel/BrowserTabPreloader.swift
@@ -1,0 +1,82 @@
+// This file is part of Kiwix for iOS & macOS.
+//
+// Kiwix is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// any later version.
+//
+// Kiwix is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kiwix; If not, see https://www.gnu.org/licenses/.
+
+import CoreData
+import Foundation
+import SwiftUI
+
+/// Preload browser tabs on app start
+/// Applicable on iOS mostly. On macOS all windows are loading in parallel already.
+/// To really start we need 2 things completed:
+/// 1) inactive tabs defined (from DB) with the selected/active tabID
+/// 2) we want to start only after the first tab has been loaded
+///    in order not to interfere with start up time
+@MainActor final class BrowserTabPreloader {
+    
+    @MainActor static let shared = BrowserTabPreloader()
+    private var openTabs: [NSManagedObjectID: UUID] = [:]
+    private var isFirstBrowserTabLoaded = false
+    private var isPreloading = false
+    
+    private init() {}
+    
+    func didLoadFirstBrowserTab() {
+        Log.LibraryOperations.debug("BrowserTabPreloader::\(#function)")
+        isFirstBrowserTabLoaded = true
+        preload()
+    }
+    
+    func start(with tabs: FetchedResults<Tab>, selectedTabId: NSManagedObjectID) {
+        Log.LibraryOperations.debug("BrowserTabPreloader::start(with: \(tabs.count))")
+        openTabs = tabs.reduce(into: [:]) { partialDict, tab in
+            let tabId = tab.objectID
+            // preloading is only for inactive tabs with a ZIM file
+            if tabId != selectedTabId, let zimFileID = tab.zimFile?.fileID {
+                partialDict[tabId] = zimFileID
+            }
+        }
+        preload()
+    }
+    
+    private func preload() {
+        guard !isPreloading, !openTabs.isEmpty, isFirstBrowserTabLoaded else { return }
+        isPreloading = true
+        Log.LibraryOperations.debug("BrowserTabPreloader::preload for: \(self.openTabs.count)")
+        
+        let zimFileIds = Set(openTabs.values)
+        let tabIDs = openTabs.keys
+        Task.detached(priority: .utility) {
+            for zimFileId in zimFileIds {
+                _ = await ZimFileService.shared.openArchive(zimFileID: zimFileId)
+                // pre-heat the ZIM file cache
+                if let mainURL = await ZimFileService.shared.getMainPageURL(zimFileID: zimFileId) {
+                    _ = await ZimFileService.shared.getURLContent(url: mainURL)
+                }
+            }
+            for tabID in tabIDs {
+                await MainActor.run {
+                    _ = BrowserViewModel.getCached(tabID: tabID)
+                }
+            }
+            await MainActor.run {
+                self.cleanUp()
+            }
+        }
+    }
+    
+    private func cleanUp() {
+        openTabs.removeAll()
+    }
+}

--- a/ViewModel/BrowserViewModel.swift
+++ b/ViewModel/BrowserViewModel.swift
@@ -169,11 +169,13 @@ import CoreKiwix
             guard let title, let url else { return }
             self?.didUpdate(title: title, url: url)
         }
-
         isLoadingObserver = webView.observe(\.isLoading, options: .new) { [weak self] _, change in
             Task { @MainActor [weak self] in
                 if change.newValue != self?.isLoading {
                     self?.isLoading = change.newValue
+                }
+                if change.newValue == false {
+                    BrowserTabPreloader.shared.didLoadFirstBrowserTab()                    
                 }
             }
         }

--- a/Views/Buttons/TabsManagerButton.swift
+++ b/Views/Buttons/TabsManagerButton.swift
@@ -13,9 +13,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Kiwix; If not, see https://www.gnu.org/licenses/.
 
+#if os(iOS) // iPhone only
 import SwiftUI
 
-#if os(iOS) // iPhone only
 struct TabsManagerButton: View {
     @EnvironmentObject private var navigation: NavigationViewModel
     @State private var presentedSheet: PresentedSheet?
@@ -129,6 +129,12 @@ struct TabManager: View {
             } primaryAction: {
                 navigation.createTab()
             }
+        }
+        .task {
+            guard case let .tab(selectedTabId) = navigation.currentItem else {
+                return
+            }
+            BrowserTabPreloader.shared.start(with: tabs, selectedTabId: selectedTabId)
         }
     }
 }


### PR DESCRIPTION
Fixes: #1479

The iPad version of the app allows to have multiple tabs open,
and change between them with 1 tap.
We are talking about the scenario, when the application and the initially selected tab is already loaded.
Now, if we switch from 1 tab to another, the first time we did that it wasn't smooth.
Many steps had to be taken to load another tab:
- if the other tab comes from another ZIM file, the ZIM file had to be opened
- the browser instance related to that tab had to be created
- the content of that page had to be load

Solution:
Preload browser tabs and ZIM files for the inactive (not currently selected) tabs,
but only do this on iPad, and only after the first tab has been loaded,
in order not to make the start up time worse.


## BEFORE

https://github.com/user-attachments/assets/ce28aae5-05b5-42bb-9c52-2cc7619cfe06


## AFTER

https://github.com/user-attachments/assets/55d04e7b-51b3-4572-ae10-e5e106f4eaa7

