### PR TITLE
Stop using pull_request_target trigger in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   workflow_dispatch:
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 name: CI
 
 on:
-  pull_request_target:
   workflow_dispatch:
+  pull_request:
   push:
     branches:
       - main
@@ -10,7 +10,7 @@ on:
 jobs:
   authorize:
     # sets environment based on origin of PR: internal (non-existent) for own-repo or external (requires reviewer to run) for external repos
-    environment: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'external' || 'internal' }}
+    environment: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'external' || 'internal' }}
     runs-on: ubuntu-22.04
     steps:
       - run: true
@@ -29,9 +29,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          # /!\ important: this checks out code from the HEAD of the PR instead of the main branch (for pull_request_target)
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Validate localizations
         run: python localizations.py validate


### PR DESCRIPTION
Fixes #1588

Instead use "simple" `pull_request` trigger which implies:
* Using the workflow in the CI (for everybody)
* Keep approving the CI run for external PR (but approver has to check properly the PR content to be sure CI secrets are not exposed)
* Implement #1589 in a second PR