### PR TITLE
Update OPDS URL

### DIFF
--- a/ViewModel/LibraryViewModel.swift
+++ b/ViewModel/LibraryViewModel.swift
@@ -60,7 +60,7 @@ final class LibraryViewModel: ObservableObject {
     private var insertionCount = 0
     private var deletionCount = 0
     
-    private static let catalogURL = URL(string: "https://opds.library.kiwix.org/v2/entries?count=-1")!
+    private static let catalogURL = URL(string: "https://opds.library.kiwix.org/catalog/v2/entries?count=-1")!
 
     init(
         urlSession: URLSession = URLSession.shared,

--- a/Views/BuildingBlocks/Favicon.swift
+++ b/Views/BuildingBlocks/Favicon.swift
@@ -70,12 +70,11 @@ struct Favicon: View {
 
 struct Favicon_Previews: PreviewProvider {
     static var previews: some View {
+        let img = "https://opds.library.kiwix.org/catalog/v2/illustration/7b656250-40ad-8d4d-5fa2-1486590278da/?size=48"
         Favicon(
             category: .wikipedia,
             imageData: nil,
-            imageURL: URL(
-                string: "https://opds.library.kiwix.org/catalog/v2/illustration/e82e6816-a2dc-a7f0-2d15-58d24709db93/?size=48"
-            )!
+            imageURL: URL(string: img)!
         ).frame(width: 200, height: 200).previewLayout(.sizeThatFits)
         Favicon(
             category: .ted,

--- a/Views/BuildingBlocks/Favicon.swift
+++ b/Views/BuildingBlocks/Favicon.swift
@@ -74,7 +74,7 @@ struct Favicon_Previews: PreviewProvider {
             category: .wikipedia,
             imageData: nil,
             imageURL: URL(
-                string: "https://opds.library.kiwix.org/v2/illustration/e82e6816-a2dc-a7f0-2d15-58d24709db93/?size=48"
+                string: "https://opds.library.kiwix.org/catalog/v2/illustration/e82e6816-a2dc-a7f0-2d15-58d24709db93/?size=48"
             )!
         ).frame(width: 200, height: 200).previewLayout(.sizeThatFits)
         Favicon(


### PR DESCRIPTION
We changed OPDS access URL last year to https://opds.library.kiwix.org/v2

Eventually, https://github.com/kiwix/libkiwix/issues/1263 showed that we can't remove the (now redundant) `/catalog` prefix. 

The now correct/recommended URL is https://opds.library.kiwix.org/catalog/v2

There is a redirect on `/v2` for the time being.