### PR TITLE
Center welcome screen

### DIFF
--- a/App/SplitViewForiPad.swift
+++ b/App/SplitViewForiPad.swift
@@ -114,8 +114,8 @@ struct SplitViewForiPad: View { // swiftlint:disable:this type_body_length
             }
         }
         .task {
-            await loadDonations()
             await observeHasZimFiles()
+            await loadDonations()
             observeNavigateToHotspotSettings()
             // set up the default selection
             // as direct opening a file (when the app is not launched)

--- a/Views/BuildingBlocks/LoadingView.swift
+++ b/Views/BuildingBlocks/LoadingView.swift
@@ -145,7 +145,7 @@ struct LogoView: View {
                     x: geometry.size.width * 0.5,
                     y: logoCalc.logoCenterY
                 )
-            }.ignoresSafeArea()
+        }.ignoresSafeArea(.all, edges: .vertical)
     }
 }
 
@@ -198,12 +198,12 @@ struct FetchingCatalogView: View {
     }
 }
 
-struct LoadingDataView: View {
+struct LoadingDataView: View {    
     var body: some View {
         ZStack {
             LogoView()
             LoadingMessageView(message: LocalString.welcome_loading_data_text)
-        }.ignoresSafeArea()
+        }.ignoresSafeArea(.all, edges: .vertical)
     }
 }
 

--- a/Views/WelcomeCatalog.swift
+++ b/Views/WelcomeCatalog.swift
@@ -29,7 +29,7 @@ struct WelcomeCatalog: View {
         ZStack {
             LogoView()
             welcomeContent
-        }.ignoresSafeArea()
+        }.ignoresSafeArea(.all, edges: .vertical)
     }
 
     private var welcomeContent: some View {


### PR DESCRIPTION
Fixes: #1610 

The best I could create so far was this (still not fully ideal), launching sequence depending on either having a ZIM file or not having any ZIM files:

## user has ZIM files
https://github.com/user-attachments/assets/e8277cd4-ff19-4c53-b866-12c2d1d227a6

## user has no ZIM file
https://github.com/user-attachments/assets/d09d148d-6076-4532-bb8b-a74c24ec28d6

## adaptive
With this newer solution though, the placement is adjusting to the side bar:

https://github.com/user-attachments/assets/a044800e-e5b9-48f9-a298-bce9a51299db