### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,12 @@ To get started, you will need the following:
 
 ### Steps
  1) clone this repository
- 2) from the project folder **run the following command: `brew bundle`**
+ 2) from the project folder **run the following commands:** 
+ ```
+ brew bundle
+ python localizations.py generate
+ xcodegen
+ ```
 
 ### Xcode settings
 


### PR DESCRIPTION
Updating our README.

Since Brew disabled post install scripts for security reasons, those additional commands (from the Brewfile) must to be run manually to get started (luckily only once).