### PR TITLE
Block external resources earlier - fix

### DIFF
--- a/App/App_iOS.swift
+++ b/App/App_iOS.swift
@@ -30,9 +30,11 @@ struct Kiwix: App {
     @StateObject private var colorSchemeStore = UserColorSchemeStore()
     
     init() {
+        Task {
+            await WebContentBlocker.compilePolicy()
+        }
         Task(priority: .utility) {
             await Diagnostics.start()
-            await WebContentBlocker.compilePolicy()
         }
         UNUserNotificationCenter.current().delegate = appDelegate
         // MARK: - migrations

--- a/App/App_macOS.swift
+++ b/App/App_macOS.swift
@@ -58,9 +58,11 @@ struct Kiwix: App {
 
     init() {
         UNUserNotificationCenter.current().delegate = notificationCenterDelegate
+        Task {
+            await WebContentBlocker.compilePolicy()            
+        }
         Task(priority: .utility) {
             await Diagnostics.start()
-            await WebContentBlocker.compilePolicy()
             if FeatureFlags.hasLibrary {
                 await LibraryViewModel().start(isUserInitiated: false)
             }


### PR DESCRIPTION
While testing things for https://github.com/kiwix/kiwix-apple/issues/1452,
I have noticed that our earlier solution from here: https://github.com/kiwix/kiwix-apple/pull/1468,
combined with our new pre-loading, it turned out that it is not always effective.

Since the blocking rule set is "compiled" on a utility task, in certain cases the webpage configuration might start earlier than the blocker rule set is ready, which is not good.

Fixing it by moving this rule set on a higher priority task, that is executing before any web view configuration could happen.
