### PR TITLE
Rename Main Page and New Tab to Start Page

### DIFF
--- a/Support/en.lproj/Localizable.strings
+++ b/Support/en.lproj/Localizable.strings
@@ -57,7 +57,7 @@
 
 "common.tab.manager.title" = "Tabs Manager";
 "common.tab.navigation.title" = "Tabs";
-"common.tab.menu.new_tab" = "New Tab";
+"common.tab.menu.new_tab" = "Start Page";
 "common.tab.menu.close_this" = "Close This Tab";
 "common.tab.menu.close_all" = "Close All Tabs";
 "common.tab.list.close" = "Close Tab";
@@ -270,7 +270,7 @@
 "search_result.filter_hearder.button.none" = "None";
 "search_result.filter_hearder.button.all" = "All";
 
-"welcome.main_page.title" = "Main Page";
+"welcome.main_page.title" = "Start Page";
 "welcome.grid.bookmarks.title" = "Bookmarks";
 "welcome.actions.open_file" = "Open File";
 "welcome.loading.data.text" = "Loading Data...";


### PR DESCRIPTION
Fixes: #1618 

As mentioned in the issue, I think we are trying to solve the wrong problem.
We are already doing what Safari does, ordering the tabs by the time of creation, it is just named the wrong way.

## Safari

https://github.com/user-attachments/assets/f68165fa-febc-41f2-bd16-01019b4a53bd


## Kiwix iPad

https://github.com/user-attachments/assets/c0430af1-5e47-4f34-9186-3a8b9aa1be77


## Kiwix iPhone
<img width="296" height="640" alt="IMG_3615 Large" src="https://github.com/user-attachments/assets/22711b13-c4c3-4728-9e4f-bcf4a845824b" />

