### PR TITLE
Enforce a single empty tab always on iOS

### DIFF
--- a/App/CompactViewController.swift
+++ b/App/CompactViewController.swift
@@ -27,6 +27,10 @@ struct CompactTabView: View {
     @State private var presentedSheet: PresentedSheet?
     @ObservedObject private var browser: BrowserViewModel
     @FocusedValue(\.hasZIMFiles) var hasZimFiles
+    @FetchRequest(
+        sortDescriptors: [],
+        predicate: Tab.Predicate.hasZimFile(),
+    ) private var tabs: FetchedResults<Tab>
     private let navigateToHotspotSettings = NotificationCenter.default.publisher(for: .navigateToHotspotSettings)
     private let hotspotShareURL = NotificationCenter.default.publisher(for: .hotspotShareURL)
     
@@ -87,8 +91,10 @@ struct CompactTabView: View {
                         browser?.webView.goForward()
                     })
                 SpacerBackCompatible()
-                TabsManagerButton()
-                SpacerBackCompatible()
+                if tabs.count > 0 {
+                    TabsManagerButton()
+                    SpacerBackCompatible()
+                }
                 if FeatureFlags.hasLibrary {
                     Button {
                         presentedSheet = .library(downloads: false)

--- a/App/SplitViewForiPad.swift
+++ b/App/SplitViewForiPad.swift
@@ -62,26 +62,18 @@ struct SplitViewForiPad: View { // swiftlint:disable:this type_body_length
             .listStyle(.sidebar)
             .navigationTitle(Brand.appName)
             .toolbar {
-                Menu {
-                    Button(role: .destructive) {
-                        guard case let .tab(tabID) = navigation.currentItem else { return }
-                        Task { [weak navigation] in
-                            await navigation?.deleteTab(tabID: tabID)
+                if hasNonEmptyTab() {
+                    Menu {
+                        Button(role: .destructive) {
+                            Task { [weak navigation] in
+                                await navigation?.deleteAllTabs(keepEmpty: true)
+                            }
+                        } label: {
+                            Label(LocalString.common_tab_menu_close_all, systemImage: "xmark.square.fill")
                         }
                     } label: {
-                        Label(LocalString.common_tab_menu_close_this, systemImage: "xmark.square")
+                        Label(LocalString.common_tab_menu_close_all, systemImage: "xmark.square")
                     }
-                    Button(role: .destructive) {
-                        Task { [weak navigation] in
-                            await navigation?.deleteAllTabs()
-                        }
-                    } label: {
-                        Label(LocalString.common_tab_menu_close_all, systemImage: "xmark.square.fill")
-                    }
-                } label: {
-                    Label(LocalString.common_tab_menu_new_tab, systemImage: "plus.square")
-                } primaryAction: {
-                    navigation.createTab()
                 }
             }
         } detail: {
@@ -152,6 +144,12 @@ struct SplitViewForiPad: View { // swiftlint:disable:this type_body_length
         }
     }
     
+    private func hasNonEmptyTab() -> Bool {
+        tabs.contains { tab in
+            tab.zimFile != nil
+        }
+    }
+    
     @ViewBuilder
     private func sectionFor(_ section: MenuSection) -> some View {
         if section == .tabs {
@@ -163,12 +161,14 @@ struct SplitViewForiPad: View { // swiftlint:disable:this type_body_length
                     .id(tab.id)
                     .accessibilityIdentifier(tab.title ?? LocalString.common_tab_menu_new_tab)
                     .swipeActions(edge: .trailing, allowsFullSwipe: true) {
-                        Button(role: .destructive) {
-                            Task { [weak navigation] in
-                                await navigation?.deleteTab(tabID: tab.objectID)
+                        if tab.zimFile != nil {
+                            Button(role: .destructive) {
+                                Task { [weak navigation] in
+                                    await navigation?.deleteTab(tabID: tab.objectID)
+                                }
+                            } label: {
+                                Label(LocalString.sidebar_view_navigation_button_close, systemImage: "xmark")
                             }
-                        } label: {
-                            Label(LocalString.sidebar_view_navigation_button_close, systemImage: "xmark")
                         }
                     }
                 }

--- a/Model/Entities/Entities.swift
+++ b/Model/Entities/Entities.swift
@@ -144,6 +144,20 @@ final class Tab: NSManagedObject, Identifiable {
         return request
     }
     
+    static func fetchRequestEmptyTabs() -> NSFetchRequest<Tab> {
+        // swiftlint:disable:next force_cast
+        let request = super.fetchRequest() as! NSFetchRequest<Tab>
+        request.predicate = Predicate.noZimFile()
+        return request
+    }
+    
+    static func fetchRequestNonEmptyTabs() -> NSFetchRequest<Tab> {
+        // swiftlint:disable:next force_cast
+        let request = super.fetchRequest() as! NSFetchRequest<Tab>
+        request.predicate = Predicate.hasZimFile()
+        return request
+    }
+    
     static func fetchRequest(byZimFileIds zimFileIds: [UUID]) -> NSFetchRequest<Tab> {
         // swiftlint:disable:next force_cast
         let request = super.fetchRequest() as! NSFetchRequest<Tab>
@@ -175,8 +189,11 @@ final class Tab: NSManagedObject, Identifiable {
         private static func zimFileNotMissing() -> NSPredicate {
             NSPredicate(format: "zimFile.isMissing == false")
         }
-        private static func noZimFile() -> NSPredicate {
+        static func noZimFile() -> NSPredicate {
             NSPredicate(format: "zimFile == nil")
+        }
+        static func hasZimFile() -> NSPredicate {
+            NSPredicate(format: "zimFile != nil")
         }
     }
 }

--- a/SwiftUI/Patches.swift
+++ b/SwiftUI/Patches.swift
@@ -88,6 +88,7 @@ extension Notification.Name {
     #if os(iOS)
     static let openDonations = Notification.Name("openDonations")
     static let hotspotShareURL = Notification.Name("hotspotShareURL")
+    static let enforceOneEmptyTab = Notification.Name("enforceOneEmptyTab")
     #endif
 }
 

--- a/ViewModel/BrowserViewModel.swift
+++ b/ViewModel/BrowserViewModel.swift
@@ -267,6 +267,21 @@ import CoreKiwix
             let context = Database.shared.viewContext
             if let tab = try? context.existingObject(with: tabID) as? Tab {
                 tab.title = articleTitle
+#if os(iOS)
+                // navigating from empty tab to a zimfile
+                let isNavigatingAwayFromEmptyTab = tab.zimFile == nil && zimFile != nil
+                if isNavigatingAwayFromEmptyTab {
+                    // set back the date of creation of this tab to now
+                    // new tabs are created with a distant future date
+                    // so they always come first
+                    tab.created = Date()
+                }
+                defer {
+                    if isNavigatingAwayFromEmptyTab {
+                        NotificationCenter.default.post(name: .enforceOneEmptyTab, object: nil)
+                    }
+                }
+#endif
                 tab.zimFile = zimFile
             }
             if context.hasChanges {

--- a/ViewModel/NavigationViewModel.swift
+++ b/ViewModel/NavigationViewModel.swift
@@ -50,12 +50,58 @@ final class NavigationViewModel: ObservableObject {
 
     private var currentTabIdValue: NSManagedObjectID?
     #endif
+    
+    #if os(iOS)
+    
+    private var emptyTabChangedTask: Task<Void, Never>?
+    
+    init() {
+        enforceOneOnlyOneEmptyTab()
+        emptyTabChangedTask = Task {
+            for await _ in NotificationCenter.default.notifications(named: .enforceOneEmptyTab) {
+                enforceOneOnlyOneEmptyTab()
+            }
+        }
+    }
+    
+    /// make sure we have 1 and only 1 empty tab
+    private func enforceOneOnlyOneEmptyTab() {
+        let context = Database.shared.viewContext
+        if var emptyTabs = try? context.fetch(Tab.fetchRequestEmptyTabs()) {
+            switch emptyTabs.count {
+            case 0:
+                _ = Self.makeTab(context: context)
+            case 1:
+                // this is what we want
+                // but make sure it's the first in the list
+                // with a distant date no other tab can match
+                emptyTabs.first?.created = Date.distantFuture
+            default:
+                // remove all the extra ones
+                while emptyTabs.count > 1 {
+                    let tabToDelete = emptyTabs.removeFirst()
+                    context.delete(tabToDelete)
+                }
+                if context.hasChanges {
+                    try? context.save()
+                }
+            }
+        }
+    }
+    
+    #endif
 
     // MARK: - Tab Management
 
     nonisolated static func makeTab(context: NSManagedObjectContext) -> Tab {
         let tab = Tab(context: context)
+        #if os(iOS)
+        // make sure it's always ordered as first
+        // with a creation date, no other tab can match
+        tab.created = Date.distantFuture
+        #else
         tab.created = Date()
+        #endif
         tab.lastOpened = Date()
         try? context.obtainPermanentIDs(for: [tab])
         try? context.save()
@@ -170,11 +216,18 @@ final class NavigationViewModel: ObservableObject {
     }
 
     /// Delete all tabs, and open a new tab
-    func deleteAllTabs() async {
+    /// - Parameter keepEmpty: on iOS we do want to keep the empty one
+    func deleteAllTabs(keepEmpty: Bool = false) async {
         let tabIdsToDelete = await Database.shared.viewContext.perform {
             let context = Database.shared.viewContext
-            // delete all existing tabs
-            let tabs = try? context.fetch(Tab.fetchRequest())
+            let request = if keepEmpty {
+                // delete all non empty ones
+                Tab.fetchRequestNonEmptyTabs()
+            } else {
+                // delete all existing tabs
+                Tab.fetchRequest()
+            }
+            let tabs = try? context.fetch(request)
             var tabIds: [NSManagedObjectID] = []
             tabs?.forEach {
                 tabIds.append($0.objectID)

--- a/Views/Buttons/TabsManagerButton.swift
+++ b/Views/Buttons/TabsManagerButton.swift
@@ -28,11 +28,6 @@ struct TabsManagerButton: View {
     var body: some View {
         Menu {
             Section {
-                Button {
-                    navigation.createTab()
-                } label: {
-                    Label(LocalString.common_tab_menu_new_tab, systemImage: "plus.square")
-                }
                 Button(role: .destructive) {
                     guard case .tab(let tabID) = navigation.currentItem else { return }
                     Task { [weak navigation] in
@@ -43,7 +38,7 @@ struct TabsManagerButton: View {
                 }
                 Button(role: .destructive) {
                     Task { [weak navigation] in
-                        await navigation?.deleteAllTabs()
+                        await navigation?.deleteAllTabs(keepEmpty: true)
                     }
                 } label: {
                     Label(LocalString.common_tab_menu_close_all, systemImage: "xmark.square.fill")
@@ -95,12 +90,14 @@ struct TabManager: View {
                 navigation.currentItem == NavigationItem.tab(objectID: tab.objectID) ? Color.blue.opacity(0.2) : nil
             )
             .swipeActions {
-                Button(role: .destructive) {
-                    Task { [weak navigation] in
-                        await navigation?.deleteTab(tabID: tab.objectID)
+                if tab.zimFile != nil {
+                    Button(role: .destructive) {
+                        Task { [weak navigation] in
+                            await navigation?.deleteTab(tabID: tab.objectID)
+                        }
+                    } label: {
+                        Label(LocalString.common_tab_list_close, systemImage: "xmark")
                     }
-                } label: {
-                    Label(LocalString.common_tab_list_close, systemImage: "xmark")
                 }
             }
         }
@@ -110,24 +107,14 @@ struct TabManager: View {
         .toolbar {
             Menu {
                 Button(role: .destructive) {
-                    guard case let .tab(tabID) = navigation.currentItem else { return }
                     Task { [weak navigation] in
-                        await navigation?.deleteTab(tabID: tabID)                    
-                    }
-                } label: {
-                    Label(LocalString.common_tab_menu_close_this, systemImage: "xmark.square")
-                }
-                Button(role: .destructive) {
-                    Task { [weak navigation] in
-                        await navigation?.deleteAllTabs()
+                        await navigation?.deleteAllTabs(keepEmpty: true)
                     }
                 } label: {
                     Label(LocalString.common_tab_menu_close_all, systemImage: "xmark.square.fill")
                 }
             } label: {
-                Label(LocalString.common_tab_menu_new_tab, systemImage: "plus.square")
-            } primaryAction: {
-                navigation.createTab()
+                Label(LocalString.common_tab_menu_close_all, systemImage: "xmark.square")
             }
         }
         .task {


### PR DESCRIPTION
Fixes: #1618 

Enforcing a single new tab to be always available.
I have updated the tab logic around it to make it usable and rule out inconsistencies:
- new tab cannot be swiped left to close
- I removed the close this tab button from the menu, it was a duplicate of the native swipe left to close, and did not make any sense if the selection was on something else than a tab (eg: on Downloads)
- Conditionally hiding the tabs close menu on iPad, if all we have is an empty tab
- Conditionally hiding the tabs menu button on iPhone, if all we have is an empty tab

# iPad

https://github.com/user-attachments/assets/f0f9ba9d-2cdf-4349-b03f-e80d5d44cbad


# iPhone

https://github.com/user-attachments/assets/305e16c9-28e9-490c-a6e4-240c9a4ddbc0


# mac
No change here.