### PR TITLE
Change photos permission to write only

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -23,7 +23,7 @@ settings:
     INFOPLIST_KEY_LSApplicationCategoryType: public.app-category.reference
     INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone: UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight
     INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad: UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight
-    INFOPLIST_KEY_NSPhotoLibraryUsageDescription: "Kiwix needs permission to saves images to your photos app."
+    INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription: "Kiwix needs permission to save images to your photos app."
     INFOPLIST_KEY_NSLocationWhenInUseUsageDescription: "Kiwix can share your location with map content from ZIM files you open."
     INFOPLIST_KEY_NSLocationUsageDescription: "Kiwix can share your location with map content from ZIM files you open."
     INFOPLIST_KEY_LSSupportsOpeningDocumentsInPlace: YES


### PR DESCRIPTION
Related to: #1436 

It might fix the issue... I am not sure, still cannot reproduce it. 
As far as I know we don't need to read from Photos, so a write only permission to Photos folder should be enough for the Kiwix app.