### PR TITLE
Keep new tab at the end of the list and reuse existing empty tabs

### DIFF
--- a/App/SplitViewForiPad.swift
+++ b/App/SplitViewForiPad.swift
@@ -81,7 +81,7 @@ struct SplitViewForiPad: View { // swiftlint:disable:this type_body_length
                 } label: {
                     Label(LocalString.common_tab_menu_new_tab, systemImage: "plus.square")
                 } primaryAction: {
-                    navigation.createTab()
+                    navigation.openNewTab()
                 }
             }
         } detail: {

--- a/Model/Entities/Entities.swift
+++ b/Model/Entities/Entities.swift
@@ -175,7 +175,7 @@ final class Tab: NSManagedObject, Identifiable {
         private static func zimFileNotMissing() -> NSPredicate {
             NSPredicate(format: "zimFile.isMissing == false")
         }
-        private static func noZimFile() -> NSPredicate {
+        static func noZimFile() -> NSPredicate {
             NSPredicate(format: "zimFile == nil")
         }
     }

--- a/ViewModel/NavigationViewModel.swift
+++ b/ViewModel/NavigationViewModel.swift
@@ -77,6 +77,22 @@ final class NavigationViewModel: ObservableObject {
         }
     }
 
+    func openNewTab() {
+        let context = Database.shared.viewContext
+        let fetchRequest = Tab.fetchRequest(
+            predicate: Tab.Predicate.noZimFile(),
+            sortDescriptors: [NSSortDescriptor(key: "created", ascending: false)]
+        )
+        fetchRequest.fetchLimit = 1
+        if let existingTab = try? context.fetch(fetchRequest).first {
+            #if !os(macOS)
+            currentItem = NavigationItem.tab(objectID: existingTab.objectID)
+            #endif
+            return
+        }
+        createTab()
+    }
+
     @discardableResult
     func createTab() -> NSManagedObjectID {
         let context = Database.shared.viewContext

--- a/Views/Buttons/TabsManagerButton.swift
+++ b/Views/Buttons/TabsManagerButton.swift
@@ -29,7 +29,7 @@ struct TabsManagerButton: View {
         Menu {
             Section {
                 Button {
-                    navigation.createTab()
+                    navigation.openNewTab()
                 } label: {
                     Label(LocalString.common_tab_menu_new_tab, systemImage: "plus.square")
                 }
@@ -79,7 +79,7 @@ struct TabManager: View {
     @Environment(\.dismiss) private var dismiss: DismissAction
     @EnvironmentObject private var navigation: NavigationViewModel
     @FetchRequest(
-        sortDescriptors: [SortDescriptor(\Tab.created, order: .reverse)],
+        sortDescriptors: [SortDescriptor(\Tab.created, order: .forward)],
         predicate: Tab.Predicate.notMissing(),
         animation: .easeInOut
     ) private var tabs: FetchedResults<Tab>
@@ -127,7 +127,7 @@ struct TabManager: View {
             } label: {
                 Label(LocalString.common_tab_menu_new_tab, systemImage: "plus.square")
             } primaryAction: {
-                navigation.createTab()
+                navigation.openNewTab()
             }
         }
         .task {


### PR DESCRIPTION
Fixes #1618

## Summary
- Changed tab list sort order on iPhone from descending to ascending (by creation date), so new tabs appear at the **end** of the list — matching the iPad sidebar which already sorted this way.
- Added `openNewTab()` in `NavigationViewModel` that checks for an existing empty tab (no associated ZIM file) before creating a new one. If one exists, it switches to it instead of creating a duplicate.
- Updated all "New Tab" button actions (iPhone tab manager + iPad sidebar) to use `openNewTab()`.

## Test plan
- [ ] Open the app on iPhone, create a new tab — verify it appears at the bottom of the tab list
- [ ] Tap "New Tab" again — verify it switches to the existing empty tab instead of creating a second one
- [ ] Open a ZIM article in the empty tab, then tap "New Tab" — verify a new empty tab is created at the end
- [ ] Repeat on iPad sidebar — same behavior expected