### PR TITLE
Add subtitle to Hotspot service

### DIFF
--- a/Support/en.lproj/Localizable.strings
+++ b/Support/en.lproj/Localizable.strings
@@ -117,6 +117,7 @@
 "hotspot.action.start_hotspot.title" = "Start Hotspot";
 "hotspot.action.stop_hotspot.title" = "Stop Hotspot";
 "hotspot.settings.port_number" = "Port number";
+"hotspot.select_zim_files.message" = "Select ZIM files to start your Hotspot service.";
 "hotspot.settings.recommended_port_range" = "The network port used by the Hotspot, should be between %@ and %@";
 "hotspot.error.port_already_used_by_another_app_title" = "Hotspot can't start because port %@ is in use.";
 "hotspot.error.port_already_used_by_another_app_description" = "To fix this, close the app using it or change the Kiwix Hotspot port in settings.";

--- a/Support/qqq.lproj/Localizable.strings
+++ b/Support/qqq.lproj/Localizable.strings
@@ -86,6 +86,7 @@
 "hotspot.action.start_hotspot.title" = "A button title to start the Kiwix Hotspot with the selected files";
 "hotspot.action.stop_hotspot.title" = "A button title to stop the Kiwix Hotspot";
 "hotspot.settings.port_number" = "Label for setting the default port number for Kiwix Hotspot in settings. Eg: Port number: 4567";
+"hotspot.select_zim_files.message" = "Label explaining to the user, that first some ZIM files should be selected, and then the Hotspot can be started with those ZIM files.";
 "hotspot.settings.recommended_port_range" = "A description in settings what is the valid range the user set Hotpost network port should fall into, when setting it. It uses two number arguments a minimum and a maximum. Eg ... between 1 and 65535";
 "hotspot.error.port_already_used_by_another_app_title" = "An alert message title, that the selected port number (argument value) is already in use.";
 "hotspot.error.port_already_used_by_another_app_description" = "Alert message explanation, how to fix the occupied port number problem.\n\n\"It\" refers to the port that is already in use; see {{msg-kiwix|Apple-hotspot.error.port already used by another app title}}.";

--- a/Views/Hotspot/HotspotZimFilesSelection.swift
+++ b/Views/Hotspot/HotspotZimFilesSelection.swift
@@ -48,6 +48,10 @@ struct HotspotZimFilesSelection: View {
     
     var body: some View {
         VStack(spacing: 0) {
+            if #unavailable(iOS 26.0) {
+                Text(LocalString.hotspot_select_zim_files_message)
+                    .font(.callout)
+            }
             if zimFiles.isEmpty {
                 Message(text: LocalString.zim_file_opened_overlay_no_zim_files_at_all_message)
             } else {
@@ -94,6 +98,7 @@ struct HotspotZimFilesSelection: View {
         }
         .modifier(ToolbarRoleBrowser())
         .navigationTitle(MenuItem.hotspot.name)
+        .modifier(NavigationSubtitleModifier(LocalString.hotspot_select_zim_files_message))
         .task {
             // make sure that our selection only contains still existing ZIM files
             selection.intersection(with: Set(zimFiles))
@@ -160,5 +165,22 @@ struct HotspotZimFilesSelection: View {
         // at the end resetError is also setting hotspotError to nil
         // but it's just too slow for UI
         hotspot.resetError()
+    }
+}
+
+private struct NavigationSubtitleModifier: ViewModifier {
+    private let subtitle: String
+    
+    init(_ subtitle: String) {
+        self.subtitle = subtitle
+    }
+    
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            content
+                .navigationSubtitle(subtitle)
+        } else {
+            content
+        }
     }
 }


### PR DESCRIPTION
#### Fixes: #1637 

## Impact for end user
Clear messaging what is the step to be taken to use the Hotspot feature.


## iPhone
<img width="1206" height="2622" alt="iphone_hotspot_msg" src="https://github.com/user-attachments/assets/f25f2fc2-25d7-4bd9-8153-def9ed2fe46e" />

## iPad
<img width="2360" height="1640" alt="ipad_hotspot_msg" src="https://github.com/user-attachments/assets/58f9896a-2280-4845-b951-43037a37d52b" />

## mac
<img width="1459" height="1068" alt="mac_hotspot_msg" src="https://github.com/user-attachments/assets/1e3e66c3-fb5c-4af7-91cc-fc004632b2b7" />



### Tested on
- [x] **iPhone**
- [x] **iPad**
- [x] **mac**