### PR TITLE
Update the logic for catalog sync

### DIFF
--- a/Model/OPDSParser/Parsed.swift
+++ b/Model/OPDSParser/Parsed.swift
@@ -18,12 +18,4 @@ import Foundation
 /// Sendable data that is comming out of the OPDSParser
 struct Parsed {
     let results: [UUID: ZimFileMetaStruct]
-    
-    /// An empty result we can use to delete zim entries
-    /// Based on the assumption we insert new ones, delete the ones not on the list
-    /// Therefore an empty list will delete everything, using the same method
-    /// @see: LibraryViewModel.process(parsed: Parsed)
-    static func deletingResult() -> Parsed {
-        Parsed(results: [:])
-    }
 }

--- a/SwiftUI/Model/DefaultKeys.swift
+++ b/SwiftUI/Model/DefaultKeys.swift
@@ -41,7 +41,6 @@ extension Defaults.Keys {
         "libraryLanguageSortingMode", default: LibraryLanguageSortingMode.byCounts
     )
     static let libraryAutoRefresh = Key<Bool>("libraryAutoRefresh", default: true)
-    static let libraryUsingOldISOLangCodes = Key<Bool>("libraryUsingOldISOLangCodes", default: true)
     static let libraryLastRefresh = Key<Date?>("libraryLastRefresh")
 
     static let isFirstLaunch = Key<Bool>("isFirstLaunch", default: true)

--- a/Tests/TestDefaults.swift
+++ b/Tests/TestDefaults.swift
@@ -25,7 +25,6 @@ final class TestDefaults: NSObject, Defaulting {
         self[.categoriesToLanguages] = [:]
         self[.libraryAutoRefresh] = false
         self[.libraryETag] = ""
-        self[.libraryUsingOldISOLangCodes] = false
         self[.libraryLanguageCodes] = []
     }
     

--- a/ViewModel/LibraryViewModel.swift
+++ b/ViewModel/LibraryViewModel.swift
@@ -47,6 +47,11 @@ enum LibraryState {
 
 @MainActor
 final class LibraryViewModel: ObservableObject {
+    private struct SyncCount {
+        var inserted: UInt = 0
+        var deleted: UInt = 0
+    }
+    
     @Published private(set) var error: Error?
     /// Note: due to multiple instances of LibraryViewModel,
     /// this `state` should not be changed directly, modify the `process.state` instead
@@ -57,8 +62,7 @@ final class LibraryViewModel: ObservableObject {
     private let categories: CategoriesProtocol
 
     private let urlSession: URLSession
-    private var insertionCount = 0
-    private var deletionCount = 0
+    private var syncCount = SyncCount()
     
     private static let catalogURL = URL(string: "https://opds.library.kiwix.org/catalog/v2/entries?count=-1")!
 
@@ -78,7 +82,6 @@ final class LibraryViewModel: ObservableObject {
         }.store(in: &cancellables)
     }
 
-    // swiftlint:disable:next function_body_length
     func start(isUserInitiated: Bool) async {
         guard process.state != .inProgress else { return }
         do {
@@ -120,11 +123,6 @@ final class LibraryViewModel: ObservableObject {
                 }
             }
             let parsed = try await parse(data: data, urlHost: responseURL)
-            // delete all old ISO Lang Code entries if needed, by passing in an empty result
-            if defaults[.libraryUsingOldISOLangCodes] {
-                try await process(parsed: Parsed.deletingResult())
-                defaults[.libraryUsingOldISOLangCodes] = false
-            }
             // process the feed
             try await process(parsed: parsed)
 
@@ -141,12 +139,10 @@ final class LibraryViewModel: ObservableObject {
             process.state = .complete
 
             // logging
-            let insertedCount = insertionCount
-            let deletedCount = deletionCount
             let totalCount = parsed.results.count
             Log.OPDS.notice("""
-Refresh finished -- insertion: \(insertedCount, privacy: .public), \
-deletion: \(deletedCount, privacy: .public), \
+Refresh finished -- insertion: \(self.syncCount.inserted, privacy: .public), \
+deletion: \(self.syncCount.deleted, privacy: .public), \
 total: \(totalCount, privacy: .public)
 """)
         } catch {
@@ -267,22 +263,36 @@ total: \(totalCount, privacy: .public)
         return await parser.results()
     }
 
-    // swiftlint:disable:next function_body_length
     private func process(parsed: Parsed) async throws {
-        let existingIds: [UUID] = await Database.shared.viewContext.perform {
-            if let zimFiles = try? ZimFile.fetchRequest().execute() {
-                return zimFiles.map { $0.fileID }
-            } else {
-                return []
-            }
-        }
+        // Sync the local DB entries with the parsed feed:
+        // 0) get all downloaded ids from the local DB
+        // 1) delete not downloaded entries from the DB
+        // 2) insert new entries from the feed, exluding the already downloaded ones
+        // 3) already downloaded entries, do not touch those
+        
+        // 0) get all downloaded ids from the local DB
+        let downloadedIds = await downloadedIds()
+        
         let parsedIds: Set<UUID> = Set(parsed.results.keys)
-        let remainingIds: Set<UUID> = parsedIds.subtracting(existingIds)
+        let insertIds: Set<UUID> = parsedIds.subtracting(downloadedIds)
     
         do {
-            // insert new zim files
+            // 1) delete not downloaded entries from the DB
+            let deleteCount: Int = try await Database.shared.viewContext.perform(schedule: .enqueued) {
+                let fetchRequest: NSFetchRequest<NSFetchRequestResult> = ZimFile.fetchRequest()
+                fetchRequest.predicate = ZimFile.Predicate.notDownloaded()
+                let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
+                deleteRequest.resultType = .resultTypeCount
+                let context = Database.shared.viewContext
+                if let result = try context.execute(deleteRequest) as? NSBatchDeleteResult {
+                    return result.result as? Int ?? 0
+                }
+                return 0
+            }
+            
+            // 2) insert new entries from the feed, exluding the already downloaded ones
             let insertCount: Int = try await Database.shared.viewContext.perform(schedule: .enqueued) {
-                var zimFileIDs = remainingIds
+                var zimFileIDs = insertIds
                 let insertRequest = NSBatchInsertRequest(
                     entity: ZimFile.entity(),
                     managedObjectHandler: { zimFile in
@@ -305,27 +315,27 @@ total: \(totalCount, privacy: .public)
                 }
             }
             
-            // delete old zim entries not included in the feed
-            let deleteCount = try await Database.shared.viewContext.perform(schedule: .enqueued) {
-                let notIncludedIn = parsedIds
-                let fetchRequest: NSFetchRequest<NSFetchRequestResult> = ZimFile.fetchRequest()
-                fetchRequest.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
-                    ZimFile.Predicate.notDownloaded(),
-                    NSPredicate(format: "NOT fileID IN %@", notIncludedIn)
-                ])
-                let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
-                deleteRequest.resultType = .resultTypeCount
-                let context = Database.shared.viewContext
-                if let result = try context.execute(deleteRequest) as? NSBatchDeleteResult {
-                    return result.result as? Int ?? 0
-                }
-                return 0
-            }
-            self.insertionCount = insertCount
-            self.deletionCount = deleteCount
+            syncCount.inserted = UInt(insertCount)
+            syncCount.deleted = UInt(deleteCount)
         } catch {
             Log.OPDS.error("Error saving OPDS Data: \(error.localizedDescription, privacy: .public)")
             throw LibraryRefreshError.process
+        }
+    }
+    
+    private func downloadedIds() async -> Set<UUID> {
+        return await Database.shared.viewContext.perform {
+            let request = ZimFile.fetchRequest(predicate: ZimFile.Predicate.isDownloaded())
+            request.propertiesToFetch = ["fileID"]
+            if let zimFiles = try? request.execute() {
+                return zimFiles.reduce(Set<UUID>()) { partialResult, file in
+                    var result = partialResult
+                    result.insert(file.fileID)
+                    return result
+                }
+            } else {
+                return Set<UUID>()
+            }
         }
     }
 }


### PR DESCRIPTION
#### Fixes: #1641

## Impact for end user
After updating the the application, on the first successful catalog fetch the catalog entries will be up to date, ready for download.

## Removed:
Old fallback logic from 2024 (see: #672) for users that were on still on old ISO language codes.
Chances of users updating the app from 2024 to today will be very slim, so it's safe to remove this.

## Changed to a new approach to sync:
Sync the local DB entries with the parsed feed:
1) do not touch already downloaded files, those are not synced
2) remove local items that are not in the feed
2) insert / replace entries that are new from the feed


Notes: the remaining discussion, and notes will be continued under:
https://github.com/kiwix/kiwix-apple/issues/1673


### Tested on
- [x] **iPhone**
- [x] **iPad**
- [x] **mac**