### PR TITLE
Add motivational subheader to donation summary page as well

### DIFF
--- a/Views/Payment/PaymentSummary.swift
+++ b/Views/Payment/PaymentSummary.swift
@@ -33,9 +33,14 @@ struct PaymentSummary: View {
 
     var body: some View {
         VStack {
+            Text(LocalString.payment_donation_reason_title)
+                .font(.callout)
+                .padding()
+
             Text(LocalString.payment_summary_page_title)
                 .font(.largeTitle)
                 .padding()
+            
             if selectedAmount.isMonthly {
                 Text(LocalString.payment_selection_option_monthly).font(.title)
                     .padding()


### PR DESCRIPTION
#### Fixes: #1643

## Impact for end user
Additional motivation subtitle on the donation summary page.

## **iPhone**
<img width="589" height="1280" alt="Simulator Screenshot - iPhone 17 - 2026-07-18 at 12 02 07 Large" src="https://github.com/user-attachments/assets/dc2de40c-f2d4-4fab-a90e-6de93808a401" />


## **iPad**
<img width="1280" height="889" alt="Simulator Screenshot - iPad Air 11-inch (M4) - 2026-07-18 at 12 00 54 Large" src="https://github.com/user-attachments/assets/d73fb9ba-0c3d-412f-a04d-680f1d60b2b0" />


## **mac**
<img width="550" height="604" alt="Screenshot 2026-07-18 at 12 00 11 Large" src="https://github.com/user-attachments/assets/dbcdc8aa-8487-4ec4-be7f-aa085660ba33" />

