### PR TITLE
Multi-language category filtering

### DIFF
--- a/App/CompactViewController.swift
+++ b/App/CompactViewController.swift
@@ -118,9 +118,9 @@ struct CompactTabView: View {
         .sheet(item: $presentedSheet) { presentedSheet in
             switch presentedSheet {
             case .library(downloads: false):
-                Library(dismiss: dismiss)
+                LibraryTab(dismiss: dismiss)
             case .library(downloads: true):
-                Library(dismiss: dismiss, tabItem: .downloads)
+                LibraryTab(dismiss: dismiss, tabItem: .downloads)
             case .customHotspot:
                 SheetContent {
                     HotspotZimFilesSelection()

--- a/App/RootView_macOS.swift
+++ b/App/RootView_macOS.swift
@@ -16,6 +16,7 @@
 #if os(macOS)
 import SwiftUI
 import PassKit
+import Defaults
 
 // swiftlint:disable:next type_body_length
 struct RootView: View {
@@ -30,6 +31,8 @@ struct RootView: View {
     // Open file alerts
     @State private var isOpenFileAlertPresented = false
     @State private var openFileAlert: OpenFileAlert?
+    @State private var selectedLanguage: String = Defaults[.libraryLanguageCodes].first ?? "eng"
+    @Default(.libraryLanguageCodes) private var languages
     let openedWithWindowState: WindowState?
     
     private let primaryItems: [MenuItem] = [.bookmarks]
@@ -84,7 +87,16 @@ struct RootView: View {
             case .opened:
                 ZimFilesMultiOpened()
             case .categories:
-                DetailSidePanel(content: { ZimFilesCategories(dismiss: nil) })
+                DetailSidePanel(content: {
+                    ZimFilesCategories(languageCode: $selectedLanguage, dismiss: nil)
+                        .toolbar {
+                            if $languages.count > 1 {
+                                ToolbarItem(placement: .secondaryAction) {
+                                    ToggleAroundLanguageButton(items: $languages, selection: $selectedLanguage)
+                                }
+                            }
+                        }
+                })
                     .modifier(SearchFocused(isSearchFocused: isSearchFocused))
             case .downloads:
                 DetailSidePanel(content: { ZimFilesDownloads(dismiss: nil) })
@@ -95,6 +107,11 @@ struct RootView: View {
                 HotspotZimFilesSelection()
             default:
                 EmptyView()
+            }
+        }
+        .onChange(of: languages) {
+            if languages.count == 1 {
+                selectedLanguage = languages.first!
             }
         }
         .frame(minWidth: 650, minHeight: 500)

--- a/App/SplitViewForiPad.swift
+++ b/App/SplitViewForiPad.swift
@@ -40,6 +40,8 @@ struct SplitViewForiPad: View { // swiftlint:disable:this type_body_length
     @State private var allSections: [MenuSection] = MenuSection.allMenuSections
     @State private var menuDict: [MenuSection: [MenuItem]] = MenuSection.staticDictionary
     @State private var selection: MenuItem?
+    @State private var languages = Defaults[.libraryLanguageCodes]
+    @State private var selectedLang: String = Defaults[.libraryLanguageCodes].first ?? "eng"
     @State private var navPath = NavigationPath()
     @State private var titleUpdate: (NSManagedObjectID, String)?
     @FetchRequest(
@@ -88,7 +90,12 @@ struct SplitViewForiPad: View { // swiftlint:disable:this type_body_length
                 case .opened:
                     ZimFilesOpened()
                 case .categories:
-                    ZimFilesCategories(dismiss: nil)
+                    ZimFilesCategories(languageCode: $selectedLang, dismiss: nil)
+                        .toolbar {
+                            ToolbarItem(placement: .secondaryAction) {
+                                ToggleAroundLanguageButton(items: $languages, selection: $selectedLang)
+                            }
+                        }
                 case .new:
                     ZimFilesNew(dismiss: nil)
                 case .downloads:

--- a/Model/CategoriesToLanguage.swift
+++ b/Model/CategoriesToLanguage.swift
@@ -51,4 +51,10 @@ struct CategoriesToLanguages: CategoriesProtocol {
             has(category: category, inLanguages: contentLanguages)
         }
     }
+    
+    func categoriesIn(languageCode: String) -> [Category] {
+        return Category.allCases.filter { (category: Category) in
+            has(category: category, inLanguages: [languageCode])
+        }
+    }
 }

--- a/Support/br.lproj/Localizable.strings
+++ b/Support/br.lproj/Localizable.strings
@@ -108,7 +108,6 @@
 "language_selector.no_language.title" = "Yezh ebet";
 "language_selector.showing.header" = "O tiskouez";
 "language_selector.hiding.header" = "O kuzhat";
-"language_selector.navitation.title" = "Yezh";
 "settings.about.title" = "Diwar-benn";
 "settings.about.dependencies.name" = "Anv";
 "settings.about.dependencies.license" = "Aotre-implijout";

--- a/Support/da.lproj/Localizable.strings
+++ b/Support/da.lproj/Localizable.strings
@@ -182,7 +182,6 @@
 "language_selector.no_language.title" = "Intet sprog";
 "language_selector.showing.header" = "Viser";
 "language_selector.hiding.header" = "Skjuler";
-"language_selector.navitation.title" = "Sprog";
 "settings.about.title" = "Om";
 "settings.about.release" = "Udgiv";
 "settings.about.dependencies" = "Afhængigheder";

--- a/Support/dag.lproj/Localizable.strings
+++ b/Support/dag.lproj/Localizable.strings
@@ -139,7 +139,6 @@
 "language_selector.no_language.title" = "Balli kani";
 "language_selector.showing.header" = "N-wuhira";
 "language_selector.hiding.header" = "Sɔɣibu";
-"language_selector.navitation.title" = "Balli";
 "settings.about.title" = "Jɛndi";
 "settings.about.release" = "Bahima";
 "settings.about.dependencies" = "Doliba";

--- a/Support/de.lproj/Localizable.strings
+++ b/Support/de.lproj/Localizable.strings
@@ -180,7 +180,6 @@
 "language_selector.no_language.title" = "Keine Sprachangabe";
 "language_selector.showing.header" = "Eingeblendet:";
 "language_selector.hiding.header" = "Ausgeblendet:";
-"language_selector.navitation.title" = "Sprache";
 "settings.about.title" = "Über";
 "settings.about.release" = "Release";
 "settings.about.dependencies" = "Abhängigkeiten";

--- a/Support/en.lproj/Localizable.strings
+++ b/Support/en.lproj/Localizable.strings
@@ -231,7 +231,6 @@
 "language_selector.no_language.title" = "No language";
 "language_selector.showing.header" = "Showing";
 "language_selector.hiding.header" = "Hiding";
-"language_selector.navitation.title" = "Language";
 
 "settings.about.title" = "About";
 "settings.about.release" = "Release";

--- a/Support/es.lproj/Localizable.strings
+++ b/Support/es.lproj/Localizable.strings
@@ -188,7 +188,6 @@
 "language_selector.no_language.title" = "Idiomas Disponibles";
 "language_selector.showing.header" = "Mostrando";
 "language_selector.hiding.header" = "Ocultando";
-"language_selector.navitation.title" = "Idioma";
 "settings.about.title" = "Acerca de";
 "settings.about.release" = "Lanzamiento";
 "settings.about.dependencies" = "Dependencias";

--- a/Support/fi.lproj/Localizable.strings
+++ b/Support/fi.lproj/Localizable.strings
@@ -97,7 +97,6 @@
 "settings.miscellaneous.navigation.about" = "Tietoja";
 "settings.selected_language.title" = "Kielet";
 "language_selector.name.title" = "Nimi";
-"language_selector.navitation.title" = "Kieli";
 "settings.about.title" = "Tietoja";
 "settings.about.release" = "Julkaisu";
 "settings.about.dependencies" = "Riippuvuudet";

--- a/Support/fr.lproj/Localizable.strings
+++ b/Support/fr.lproj/Localizable.strings
@@ -203,7 +203,6 @@
 "language_selector.no_language.title" = "Pas de langue";
 "language_selector.showing.header" = "Affichage";
 "language_selector.hiding.header" = "Masquage";
-"language_selector.navitation.title" = "Langue";
 "settings.about.title" = "À propos";
 "settings.about.release" = "Publication";
 "settings.about.dependencies" = "Dépendances";

--- a/Support/ha.lproj/Localizable.strings
+++ b/Support/ha.lproj/Localizable.strings
@@ -149,7 +149,6 @@
 "language_selector.no_language.title" = "Ba yare";
 "language_selector.showing.header" = "Nunawa";
 "language_selector.hiding.header" = "Boyewa";
-"language_selector.navitation.title" = "Yare";
 "settings.about.title" = "Game da";
 "settings.about.release" = "Yanterwa";
 "settings.about.dependencies" = "abin dogara";

--- a/Support/he.lproj/Localizable.strings
+++ b/Support/he.lproj/Localizable.strings
@@ -160,7 +160,6 @@
 "language_selector.no_language.title" = "אין שפה";
 "language_selector.showing.header" = "מוצגות";
 "language_selector.hiding.header" = "מוסתרות";
-"language_selector.navitation.title" = "שפה";
 "settings.about.title" = "אודות";
 "settings.about.release" = "מהדורה";
 "settings.about.dependencies" = "תלויות";

--- a/Support/hi.lproj/Localizable.strings
+++ b/Support/hi.lproj/Localizable.strings
@@ -53,7 +53,6 @@
 "settings.selected_language.title" = "भाषाएँ";
 "language_selector.name.title" = "नाम";
 "language_selector.count.table.title" = "गणना";
-"language_selector.navitation.title" = "भाषा";
 "settings.about.dependencies.name" = "नाम";
 "settings.about.dependencies.license" = "लाइसेंस";
 "settings.about.dependencies.version" = "संस्करण";

--- a/Support/ia.lproj/Localizable.strings
+++ b/Support/ia.lproj/Localizable.strings
@@ -184,7 +184,6 @@
 "language_selector.no_language.title" = "Necun lingua";
 "language_selector.showing.header" = "Es monstrate:";
 "language_selector.hiding.header" = "Celamento";
-"language_selector.navitation.title" = "Lingua";
 "settings.about.title" = "A proposito";
 "settings.about.release" = "Edition";
 "settings.about.dependencies" = "Dependentias";

--- a/Support/id.lproj/Localizable.strings
+++ b/Support/id.lproj/Localizable.strings
@@ -152,7 +152,6 @@
 "language_selector.no_language.title" = "Tidak ada bahasa";
 "language_selector.showing.header" = "Menampilkan";
 "language_selector.hiding.header" = "Menyembunyikan";
-"language_selector.navitation.title" = "Bahasa";
 "settings.about.title" = "Tentang";
 "settings.about.release" = "Rilis";
 "settings.about.dependencies" = "Ketergantungan";

--- a/Support/ig.lproj/Localizable.strings
+++ b/Support/ig.lproj/Localizable.strings
@@ -155,7 +155,6 @@
 "language_selector.no_language.title" = "Enweghị asụsụ";
 "language_selector.showing.header" = "Na-egosi";
 "language_selector.hiding.header" = "Na-ezo";
-"language_selector.navitation.title" = "Asụsụ";
 "settings.about.title" = "Ihe banyere";
 "settings.about.release" = "Hapụ";
 "settings.about.dependencies" = "Ndabere";

--- a/Support/igl.lproj/Localizable.strings
+++ b/Support/igl.lproj/Localizable.strings
@@ -36,7 +36,6 @@
 "language_selector.no_language.title" = "Ichi den";
 "language_selector.showing.header" = "Adu nwa go";
 "language_selector.hiding.header" = "Ma ja";
-"language_selector.navitation.title" = "Ichi";
 "settings.about.dependencies" = "Lóno";
 "settings.about.dependencies.name" = "O du";
 "settings.about.build.title" = "U nyi";

--- a/Support/it.lproj/Localizable.strings
+++ b/Support/it.lproj/Localizable.strings
@@ -118,7 +118,6 @@
 "language_selector.count.table.title" = "Conteggio";
 "language_selector.no_language.title" = "Nessuna lingua";
 "language_selector.showing.header" = "Sto mostrando:";
-"language_selector.navitation.title" = "Lingua";
 "settings.about.title" = "Informazioni";
 "settings.about.dependencies.name" = "Nome";
 "settings.about.description" = "Kiwix è un lettore offline per contenuti online come Wikipedia, Project Gutenberg o TED Talks. Rende la conoscenza disponibile a persone che non hanno o hanno un accesso limitato a Internet. Il software e il contenuto sono gratuiti per chiunque.";

--- a/Support/ja.lproj/Localizable.strings
+++ b/Support/ja.lproj/Localizable.strings
@@ -148,7 +148,6 @@
 "language_selector.no_language.title" = "言語なし";
 "language_selector.showing.header" = "表示";
 "language_selector.hiding.header" = "非表示";
-"language_selector.navitation.title" = "言語";
 "settings.about.title" = "このアプリについて";
 "settings.about.release" = "リリース";
 "settings.about.dependencies" = "依存関係";

--- a/Support/kab.lproj/Localizable.strings
+++ b/Support/kab.lproj/Localizable.strings
@@ -55,7 +55,6 @@
 "language_selector.name.title" = "Isem";
 "language_selector.count.table.title" = "Amḍan";
 "language_selector.no_language.title" = "Ulac tutlayt";
-"language_selector.navitation.title" = "Tutlayt";
 "settings.about.title" = "Ɣef";
 "settings.about.dependencies.name" = "Isem";
 "settings.about.dependencies.license" = "Turagt";

--- a/Support/ko.lproj/Localizable.strings
+++ b/Support/ko.lproj/Localizable.strings
@@ -197,7 +197,6 @@
 "language_selector.no_language.title" = "언어 없음";
 "language_selector.showing.header" = "표시 중";
 "language_selector.hiding.header" = "숨기는 중";
-"language_selector.navitation.title" = "언어";
 "settings.about.title" = "정보";
 "settings.about.release" = "릴리스";
 "settings.about.dependencies" = "의존성";

--- a/Support/lb.lproj/Localizable.strings
+++ b/Support/lb.lproj/Localizable.strings
@@ -129,7 +129,6 @@
 "language_selector.count.table.title" = "Zuel";
 "language_selector.no_language.title" = "Keng Sprooch";
 "language_selector.hiding.header" = "Verstoppen";
-"language_selector.navitation.title" = "Sprooch";
 "settings.about.title" = "Iwwer";
 "settings.about.release" = "Release";
 "settings.about.dependencies" = "Ofhängegkeeten";

--- a/Support/ln.lproj/Localizable.strings
+++ b/Support/ln.lproj/Localizable.strings
@@ -14,7 +14,6 @@
 "language_selector.no_language.title" = "Elobeli te";
 "language_selector.showing.header" = "Komonisama";
 "language_selector.hiding.header" = "Kobomba";
-"language_selector.navitation.title" = "Lokótá";
 "settings.about.title" = "elɔ́kɔ elobámí";
 "settings.about.release" = "Kobimisa";
 "settings.about.dependencies.name" = "Nkómbó";

--- a/Support/mk.lproj/Localizable.strings
+++ b/Support/mk.lproj/Localizable.strings
@@ -183,7 +183,6 @@
 "language_selector.no_language.title" = "Нема јазик";
 "language_selector.showing.header" = "Приказ на";
 "language_selector.hiding.header" = "Скривање";
-"language_selector.navitation.title" = "Јазик";
 "settings.about.title" = "За прилогот";
 "settings.about.release" = "Издание";
 "settings.about.dependencies" = "Зависности";

--- a/Support/nl.lproj/Localizable.strings
+++ b/Support/nl.lproj/Localizable.strings
@@ -194,7 +194,6 @@
 "language_selector.no_language.title" = "Geen taal";
 "language_selector.showing.header" = "Weergegeven";
 "language_selector.hiding.header" = "Verborgen";
-"language_selector.navitation.title" = "Taal";
 "settings.about.title" = "Over";
 "settings.about.release" = "Uitgave";
 "settings.about.dependencies" = "Afhankelijkheden";

--- a/Support/pa.lproj/Localizable.strings
+++ b/Support/pa.lproj/Localizable.strings
@@ -105,7 +105,6 @@
 "language_selector.no_language.title" = "ਕੋਈ ਭਾਸ਼ਾ ਨਹੀਂ";
 "language_selector.showing.header" = "ਵਿਖਾ ਰਿਹਾ ਐ";
 "language_selector.hiding.header" = "ਲੁਕਾ ਰਿਹਾ ਐ";
-"language_selector.navitation.title" = "ਬੋਲੀ";
 "settings.about.title" = "ਬਾਰੇ";
 "settings.about.dependencies.name" = "ਨਾਂ";
 "settings.about.dependencies.license" = "ਲਸੰਸ";

--- a/Support/pl.lproj/Localizable.strings
+++ b/Support/pl.lproj/Localizable.strings
@@ -114,7 +114,6 @@
 "settings.selected_language.title" = "Języki";
 "language_selector.name.title" = "Nazwa";
 "language_selector.no_language.title" = "Brak języka";
-"language_selector.navitation.title" = "Język";
 "settings.about.title" = "O aplikacji";
 "settings.about.release" = "Wydanie";
 "settings.about.dependencies" = "Zależności";

--- a/Support/pt-br.lproj/Localizable.strings
+++ b/Support/pt-br.lproj/Localizable.strings
@@ -96,7 +96,6 @@
 "settings.selected_language.title" = "Idiomas";
 "language_selector.name.title" = "Nome";
 "language_selector.showing.header" = "Mostrando";
-"language_selector.navitation.title" = "Idioma";
 "settings.about.title" = "Sobre";
 "settings.about.release" = "Lançamento";
 "settings.about.dependencies" = "Dependências";

--- a/Support/qqq.lproj/Localizable.strings
+++ b/Support/qqq.lproj/Localizable.strings
@@ -195,7 +195,6 @@
 "language_selector.no_language.title" = "Fallback title for listing the languages of ZIM files in settings";
 "language_selector.showing.header" = "Section title for listing the languages in settings";
 "language_selector.hiding.header" = "Section title for listing the languages in settings";
-"language_selector.navitation.title" = "Page title for Language settings";
 "settings.about.title" = "Page title for About page in settings";
 "settings.about.release" = "Section title on About page";
 "settings.about.dependencies" = "Section title on About page";

--- a/Support/ro.lproj/Localizable.strings
+++ b/Support/ro.lproj/Localizable.strings
@@ -144,7 +144,6 @@
 "language_selector.no_language.title" = "Fără limbă";
 "language_selector.showing.header" = "Arată";
 "language_selector.hiding.header" = "Ascunde";
-"language_selector.navitation.title" = "Limbă";
 "settings.about.title" = "Despre";
 "settings.about.release" = "Lansat";
 "settings.about.dependencies" = "Dependențe";

--- a/Support/ru.lproj/Localizable.strings
+++ b/Support/ru.lproj/Localizable.strings
@@ -155,7 +155,6 @@
 "language_selector.no_language.title" = "Нет языка";
 "language_selector.showing.header" = "Показано";
 "language_selector.hiding.header" = "Скрыто";
-"language_selector.navitation.title" = "Язык";
 "settings.about.title" = "О приложении";
 "settings.about.release" = "Релиз";
 "settings.about.dependencies" = "Зависимости";

--- a/Support/se.lproj/Localizable.strings
+++ b/Support/se.lproj/Localizable.strings
@@ -62,7 +62,6 @@
 "settings.miscellaneous.navigation.about" = "Lassedieđut";
 "settings.selected_language.title" = "Gielat";
 "language_selector.name.title" = "Namma";
-"language_selector.navitation.title" = "Giella";
 "settings.about.title" = "Lassedieđut";
 "settings.about.dependencies.name" = "Namma";
 "settings.about.dependencies.license" = "Liseansa";

--- a/Support/sk.lproj/Localizable.strings
+++ b/Support/sk.lproj/Localizable.strings
@@ -192,7 +192,6 @@
 "language_selector.no_language.title" = "Žiadny jazyk";
 "language_selector.showing.header" = "Zobrazuje sa";
 "language_selector.hiding.header" = "Skrýva sa";
-"language_selector.navitation.title" = "Jazyk";
 "settings.about.title" = "O aplikácii";
 "settings.about.release" = "Vydanie";
 "settings.about.dependencies" = "Závislosti";

--- a/Support/skr-arab.lproj/Localizable.strings
+++ b/Support/skr-arab.lproj/Localizable.strings
@@ -77,7 +77,6 @@
 "language_selector.name.title" = "ناں";
 "language_selector.count.table.title" = "ڳیݨ";
 "language_selector.no_language.title" = "کوئی زبان کائنی";
-"language_selector.navitation.title" = "زبان";
 "settings.about.title" = "تعارف";
 "settings.about.release" = "ریلیز";
 "settings.about.dependencies.name" = "ناں";

--- a/Support/sl.lproj/Localizable.strings
+++ b/Support/sl.lproj/Localizable.strings
@@ -192,7 +192,6 @@
 "language_selector.no_language.title" = "Ni jezikov";
 "language_selector.showing.header" = "Prikazano:";
 "language_selector.hiding.header" = "Skrivanje";
-"language_selector.navitation.title" = "Jezik";
 "settings.about.title" = "O aplikaciji";
 "settings.about.release" = "Izdaja";
 "settings.about.dependencies" = "Odvisnosti";

--- a/Support/sq.lproj/Localizable.strings
+++ b/Support/sq.lproj/Localizable.strings
@@ -145,7 +145,6 @@
 "language_selector.no_language.title" = "Pa gjuhë";
 "language_selector.showing.header" = "Shfaqet";
 "language_selector.hiding.header" = "Fshihet";
-"language_selector.navitation.title" = "Gjuhë";
 "settings.about.title" = "Mbi";
 "settings.about.release" = "Hedhje në qarkullim";
 "settings.about.dependencies" = "Varësi";

--- a/Support/sv.lproj/Localizable.strings
+++ b/Support/sv.lproj/Localizable.strings
@@ -190,7 +190,6 @@
 "language_selector.no_language.title" = "Inget språk";
 "language_selector.showing.header" = "Visar";
 "language_selector.hiding.header" = "Döljer";
-"language_selector.navitation.title" = "Språk";
 "settings.about.title" = "Om";
 "settings.about.release" = "Utgåva";
 "settings.about.dependencies" = "Beroenden";

--- a/Support/tr.lproj/Localizable.strings
+++ b/Support/tr.lproj/Localizable.strings
@@ -139,7 +139,6 @@
 "language_selector.no_language.title" = "Dil yok";
 "language_selector.showing.header" = "Gösteriliyor";
 "language_selector.hiding.header" = "Gizleniyor";
-"language_selector.navitation.title" = "Dil";
 "settings.about.title" = "Hakkında";
 "settings.about.release" = "Sürüm";
 "settings.about.dependencies" = "Bağımlılıklar";

--- a/Support/uk.lproj/Localizable.strings
+++ b/Support/uk.lproj/Localizable.strings
@@ -154,7 +154,6 @@
 "language_selector.no_language.title" = "Немає мов";
 "language_selector.showing.header" = "Показуються";
 "language_selector.hiding.header" = "Приховуються";
-"language_selector.navitation.title" = "Мова";
 "settings.about.title" = "Про застосунок";
 "settings.about.release" = "Реліз";
 "settings.about.dependencies" = "Залежності";

--- a/Support/zh-hans.lproj/Localizable.strings
+++ b/Support/zh-hans.lproj/Localizable.strings
@@ -203,7 +203,6 @@
 "language_selector.no_language.title" = "无语言";
 "language_selector.showing.header" = "显示";
 "language_selector.hiding.header" = "隐藏";
-"language_selector.navitation.title" = "语言";
 "settings.about.title" = "关于";
 "settings.about.release" = "发行";
 "settings.about.dependencies" = "依赖项";

--- a/Support/zh-hant.lproj/Localizable.strings
+++ b/Support/zh-hant.lproj/Localizable.strings
@@ -196,7 +196,6 @@
 "language_selector.no_language.title" = "沒有語言";
 "language_selector.showing.header" = "顯示";
 "language_selector.hiding.header" = "隱藏";
-"language_selector.navitation.title" = "語言";
 "settings.about.title" = "關於";
 "settings.about.release" = "發行";
 "settings.about.dependencies" = "相依";

--- a/Tests/CategoryFetchingTests.swift
+++ b/Tests/CategoryFetchingTests.swift
@@ -38,7 +38,7 @@ final class CategoryFetchingTests: XCTestCase {
         request.predicate = ZimFilesCategory.buildPredicate(
             category: .other,
             searchText: "",
-            languageCodes: ["x"]
+            languageCode: "x"
         )
         let results = try! context.fetch(request)
         XCTAssertTrue(results.isEmpty)
@@ -57,26 +57,7 @@ final class CategoryFetchingTests: XCTestCase {
         request.predicate = ZimFilesCategory.buildPredicate(
             category: .other,
             searchText: "",
-            languageCodes: ["eng"]
-        )
-        let results = try! context.fetch(request)
-        XCTAssertEqual(results.count, 1)
-    }
-
-    @MainActor
-    func testCanBeFoundByMultipleUserLanguages() throws {
-        // insert a zimFile
-        let context = Database.shared.viewContext
-        let zimFile = ZimFile(context: context)
-        let metadata = ZimFileMetaStruct.mock(languageCodes: "fra",
-                                              category: Category.other.rawValue)
-        LibraryOperations.configureZimFile(zimFile, metadata: metadata)
-        try? context.save()
-        let request = NSFetchRequest<ZimFile>(entityName: ZimFile.entity().name!)
-        request.predicate = ZimFilesCategory.buildPredicate(
-            category: .other,
-            searchText: "",
-            languageCodes: ["eng", "deu", "fra", "ita", "por"]
+            languageCode: "eng"
         )
         let results = try! context.fetch(request)
         XCTAssertEqual(results.count, 1)
@@ -95,48 +76,10 @@ final class CategoryFetchingTests: XCTestCase {
         request.predicate = ZimFilesCategory.buildPredicate(
             category: .other,
             searchText: "",
-            languageCodes: ["spa"]
+            languageCode: "spa"
         )
         let results = try! context.fetch(request)
         XCTAssertEqual(results.count, 1)
-    }
-
-    @MainActor
-    func testCanBeFoundHavingMultiLanguageMatches() throws {
-        // insert a zimFile
-        let context = Database.shared.viewContext
-        let zimFile = ZimFile(context: context)
-        let metadata = ZimFileMetaStruct.mock(languageCodes: "eng,fra,deu,nld,spa,ita,por,pol,ara,vie,kor",
-                                              category: Category.other.rawValue)
-        LibraryOperations.configureZimFile(zimFile, metadata: metadata)
-        try? context.save()
-        let request = NSFetchRequest<ZimFile>(entityName: ZimFile.entity().name!)
-        request.predicate = ZimFilesCategory.buildPredicate(
-            category: .other,
-            searchText: "",
-            languageCodes: ["nld", "por", "fra"]
-        )
-        let results = try! context.fetch(request)
-        XCTAssertEqual(results.count, 1)
-    }
-
-    @MainActor
-    func testFilteredOutByMultiToMultiLanguageMissMatch() throws {
-        // insert a zimFile
-        let context = Database.shared.viewContext
-        let zimFile = ZimFile(context: context)
-        let metadata = ZimFileMetaStruct.mock(languageCodes: "eng,fra,deu,nld,spa,ita",
-                                              category: Category.other.rawValue)
-        LibraryOperations.configureZimFile(zimFile, metadata: metadata)
-        try? context.save()
-        let request = NSFetchRequest<ZimFile>(entityName: ZimFile.entity().name!)
-        request.predicate = ZimFilesCategory.buildPredicate(
-            category: .other,
-            searchText: "",
-            languageCodes: ["por", "pol", "ara", "vie", "kor"]
-        )
-        let results = try! context.fetch(request)
-        XCTAssertTrue(results.isEmpty)
     }
 
     private func resetDB() throws {

--- a/Views/Library/Categories/CategoryEmptySection.swift
+++ b/Views/Library/Categories/CategoryEmptySection.swift
@@ -1,0 +1,31 @@
+// This file is part of Kiwix for iOS & macOS.
+//
+// Kiwix is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// any later version.
+//
+// Kiwix is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kiwix; If not, see https://www.gnu.org/licenses/.
+
+import SwiftUI
+
+struct CategoryEmptySection: View {
+    @EnvironmentObject private var viewModel: LibraryViewModel
+    
+    var body: some View {
+        switch viewModel.state {
+        case .inProgress:
+            Message(text: LocalString.zim_file_catalog_fetching_message)
+        case .error:
+            Message(text: LocalString.library_refresh_error_retrieve_description, color: .red)
+        case .initial, .complete:
+            Message(text: LocalString.zim_file_category_section_empty_message)
+        }
+    }
+}

--- a/Views/Library/Categories/LibraryTab.swift
+++ b/Views/Library/Categories/LibraryTab.swift
@@ -19,22 +19,25 @@ import Defaults
 
 #if os(iOS)
 /// Tabbed library view on iOS & iPadOS
-struct Library: View {
+struct LibraryTab: View {
     @EnvironmentObject private var viewModel: LibraryViewModel
     @EnvironmentObject private var navigation: NavigationViewModel
+    @Default(.libraryLanguageCodes) private var libraryLanguageCodes
+    @State private var selectedLang: String
     @State private var tabItem: LibraryTabItem
     @Default(.hasSeenCategories) private var hasSeenCategories
-    private let categories: [Category]
+    @State private var categories: [Category]
     let dismiss: (() -> Void)?
 
     init(
         dismiss: (() -> Void)?,
-        tabItem: LibraryTabItem = .categories,
-        categories: [Category] = CategoriesToLanguages().allCategories()
+        tabItem: LibraryTabItem = .categories
     ) {
         self.dismiss = dismiss
         self.tabItem = tabItem
-        self.categories = categories
+        let selectedCode = Defaults[.libraryLanguageCodes].first ?? "eng"
+        self.selectedLang = selectedCode
+        self.categories = CategoriesToLanguages().categoriesIn(languageCode: selectedCode)
     }
 
     var body: some View {
@@ -45,7 +48,11 @@ struct Library: View {
                     case .categories:
                         List(categories) { category in
                             NavigationLink {
-                                ZimFilesCategory(category: .constant(category), dismiss: dismiss)
+                                ZimFilesCategory(
+                                    category: .constant(category),
+                                    languageCode: $selectedLang,
+                                    dismiss: dismiss
+                                )
                                     .navigationTitle(category.name)
                                     .navigationBarTitleDisplayMode(.inline)
                             } label: {
@@ -55,8 +62,18 @@ struct Library: View {
                                 }
                             }
                         }
+                        .toolbar {
+                            if libraryLanguageCodes.count > 1 {
+                                ToolbarItem(id: "language_picker", placement: .confirmationAction) {
+                                    ToggleAroundLanguageButton(items: $libraryLanguageCodes, selection: $selectedLang)
+                                }
+                            }
+                        }
                         .listStyle(.plain)
                         .navigationTitle(MenuItem.categories.name)
+                        .onChange(of: selectedLang) { _, newValue in
+                            categories = CategoriesToLanguages().categoriesIn(languageCode: newValue)
+                        }
                     case .opened:
                         ZimFilesOpenedNavStack(dismiss: dismiss)
                     case .downloads:
@@ -86,7 +103,7 @@ struct Library: View {
 struct Library_Previews: PreviewProvider {
     static var previews: some View {
         NavigationStack {
-            Library(dismiss: nil)
+            LibraryTab(dismiss: nil)
                 .environmentObject(LibraryViewModel())
                 .environment(\.managedObjectContext, Database.shared.viewContext)
         }

--- a/Views/Library/Categories/LibraryTab.swift
+++ b/Views/Library/Categories/LibraryTab.swift
@@ -55,6 +55,16 @@ struct LibraryTab: View {
                                 )
                                     .navigationTitle(category.name)
                                     .navigationBarTitleDisplayMode(.inline)
+                                    .toolbar {
+                                        if libraryLanguageCodes.count > 1 {
+                                            ToolbarItem(id: "language_picker", placement: .confirmationAction) {
+                                                ToggleAroundLanguageButton(
+                                                    items: $libraryLanguageCodes,
+                                                    selection: $selectedLang
+                                                )
+                                            }
+                                        }
+                                    }
                             } label: {
                                 HStack {
                                     Favicon(category: category).frame(height: 26)

--- a/Views/Library/Categories/ToggleAroundLanguageButton.swift
+++ b/Views/Library/Categories/ToggleAroundLanguageButton.swift
@@ -1,0 +1,37 @@
+// This file is part of Kiwix for iOS & macOS.
+//
+// Kiwix is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// any later version.
+//
+// Kiwix is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kiwix; If not, see https://www.gnu.org/licenses/.
+
+import SwiftUI
+
+struct ToggleAroundLanguageButton: View {
+    @Binding var items: [String]
+    @Binding var selection: String
+    
+    var body: some View {
+        Button {
+            guard let currentIndex = items.firstIndex(of: selection) else {
+                return
+            }
+            let nextIndex = (currentIndex + 1) % items.count
+
+            selection = items[nextIndex]
+        } label: {
+            let langDisplayName = Locale.current.localizedString(forIdentifier: selection) ?? selection
+            Text(langDisplayName)
+                .animation(nil)
+        }
+        .accessibilityIdentifier(selection)
+    }
+}

--- a/Views/Library/Categories/ZimFilesCategories.swift
+++ b/Views/Library/Categories/ZimFilesCategories.swift
@@ -20,15 +20,17 @@ import Defaults
 /// A grid of zim files under each category.
 struct ZimFilesCategories: View {
     @State private var selected: Category
+    @Binding private var languageCode: String
     @Default(.hasSeenCategories) private var hasSeenCategories
     private var categories: [Category]
     private let dismiss: (() -> Void)?
 
     init(
-        dismiss: (() -> Void)?,
-        categories: [Category] = CategoriesToLanguages().allCategories()
+        languageCode selectedLangCode: Binding<String>,
+        dismiss: (() -> Void)?
     ) {
-        self.categories = categories
+        _languageCode = selectedLangCode
+        let categories = CategoriesToLanguages().categoriesIn(languageCode: selectedLangCode.wrappedValue)
         let selectedCategory: Category? = {
             guard let selectedCategoryId = Defaults[.selectedCategory] else {
                 return nil
@@ -37,12 +39,13 @@ struct ZimFilesCategories: View {
                 category.id == selectedCategoryId
             }
         }()
+        self.categories = categories
         selected = selectedCategory ?? categories.first ?? .wikipedia
         self.dismiss = dismiss
     }
 
     var body: some View {
-        ZimFilesCategory(category: $selected, dismiss: dismiss)
+        ZimFilesCategory(category: $selected, languageCode: $languageCode, dismiss: dismiss)
             .modifier(ToolbarRoleBrowser())
             .navigationTitle(MenuItem.categories.name)
             .toolbar {
@@ -69,14 +72,25 @@ struct ZimFilesCategories: View {
 /// A grid or list of zim files under a single category.
 struct ZimFilesCategory: View {
     @Binding var category: Category
+    @Binding var languageCode: String
     @State private var searchText = ""
     let dismiss: (() -> Void)? // iOS only
 
     var body: some View {
         if category == .ted || category == .stackExchange || category == .other {
-            CategoryList(category: $category, searchText: $searchText, dismiss: dismiss)
+            CategoryList(
+                category: $category,
+                selectedLanguage: $languageCode,
+                searchText: $searchText,
+                dismiss: dismiss
+            )
         } else {
-            CategoryGrid(category: $category, searchText: $searchText, dismiss: dismiss)
+            CategoryGrid(
+                category: $category,
+                selectedLanguage: $languageCode,
+                searchText: $searchText,
+                dismiss: dismiss
+            )
         }
     }
 
@@ -84,15 +98,13 @@ struct ZimFilesCategory: View {
     static func buildPredicate(
         category: Category,
         searchText: String,
-        languageCodes: [String] = Defaults[.libraryLanguageCodes]
+        languageCode: String
     ) -> NSPredicate {
-        let langPredicates = languageCodes.map { langCode -> NSPredicate in
-            let regex = String(format: "(.*,)?%@(,.*)?", langCode)
-            return NSPredicate(format: "languageCode MATCHES %@", regex)
-        }
+        let regex = String(format: "(.*,)?%@(,.*)?", languageCode)
+        let langPredicate = NSPredicate(format: "languageCode MATCHES %@", regex)
         var predicates = [
             NSPredicate(format: "category == %@", category.rawValue),
-            NSCompoundPredicate(orPredicateWithSubpredicates: langPredicates),
+            langPredicate,
             NSPredicate(format: "requiresServiceWorkers == false")
         ]
         if !searchText.isEmpty {
@@ -104,15 +116,21 @@ struct ZimFilesCategory: View {
 
 private struct CategoryGrid: View {
     @Binding var category: Category
+    @Binding var selectedLanguage: String
     @Binding var searchText: String
     @Default(.libraryLanguageCodes) private var languageCodes
-    @EnvironmentObject private var viewModel: LibraryViewModel
     @EnvironmentObject private var selection: SelectedZimFileViewModel
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @SectionedFetchRequest private var sections: SectionedFetchResults<String, ZimFile>
     private let dismiss: (() -> Void)? // iOS only
 
-    init(category: Binding<Category>, searchText: Binding<String>, dismiss: (() -> Void)?) {
+    init(
+        category: Binding<Category>,
+        selectedLanguage: Binding<String>,
+        searchText: Binding<String>,
+        dismiss: (() -> Void)?
+    ) {
+        self._selectedLanguage = selectedLanguage
         self._category = category
         self._searchText = searchText
         self.dismiss = dismiss
@@ -120,7 +138,9 @@ private struct CategoryGrid: View {
             sectionIdentifier: \.name,
             sortDescriptors: [SortDescriptor(\ZimFile.name), SortDescriptor(\.size, order: .reverse)],
             predicate: ZimFilesCategory.buildPredicate(
-                category: category.wrappedValue, searchText: searchText.wrappedValue
+                category: category.wrappedValue,
+                searchText: searchText.wrappedValue,
+                languageCode: selectedLanguage.wrappedValue
             ),
             animation: .easeInOut
         )
@@ -129,14 +149,7 @@ private struct CategoryGrid: View {
     var body: some View {
         Group {
             if sections.isEmpty {
-                switch viewModel.state {
-                case .inProgress:
-                    Message(text: LocalString.zim_file_catalog_fetching_message)
-                case .error:
-                    Message(text: LocalString.library_refresh_error_retrieve_description, color: .red)
-                case .initial, .complete:
-                    Message(text: LocalString.zim_file_category_section_empty_message)
-                }
+                CategoryEmptySection()
             } else {
                 LazyVGrid(columns: ([gridItem]), alignment: .leading, spacing: 12) {
                     ForEach(sections) { section in
@@ -175,10 +188,17 @@ private struct CategoryGrid: View {
         .searchable(text: $searchText, prompt: LocalString.common_search)
         .onChange(of: category) { selection.reset() }
         .onChange(of: searchText) { _, newValue in
-            sections.nsPredicate = ZimFilesCategory.buildPredicate(category: category, searchText: newValue)
+            sections.nsPredicate = ZimFilesCategory
+                .buildPredicate(category: category, searchText: newValue, languageCode: selectedLanguage)
+        }
+        .onChange(of: selectedLanguage) {
+            sections.nsPredicate = ZimFilesCategory
+                .buildPredicate(category: category, searchText: searchText, languageCode: selectedLanguage)
         }
         .onChange(of: languageCodes) {
-            sections.nsPredicate = ZimFilesCategory.buildPredicate(category: category, searchText: searchText)
+            if !languageCodes.contains(selectedLanguage) {
+                selectedLanguage = languageCodes.first ?? "eng"
+            }
         }
     }
 
@@ -208,17 +228,19 @@ private struct CategoryGrid: View {
 
 private struct CategoryList: View {
     @Binding var category: Category
+    @Binding var selectedLanguage: String
     @Binding var searchText: String
     @Default(.libraryLanguageCodes) private var languageCodes
-    @EnvironmentObject private var viewModel: LibraryViewModel
     @EnvironmentObject private var selection: SelectedZimFileViewModel
     @FetchRequest private var zimFiles: FetchedResults<ZimFile>
     private let dismiss: (() -> Void)?
 
-    init(category: Binding<Category>, 
+    init(category: Binding<Category>,
+         selectedLanguage: Binding<String>,
          searchText: Binding<String>,
          dismiss: (() -> Void)?
     ) {
+        self._selectedLanguage = selectedLanguage
         self._category = category
         self._searchText = searchText
         self.dismiss = dismiss
@@ -230,7 +252,9 @@ private struct CategoryList: View {
                 NSSortDescriptor(keyPath: \ZimFile.size, ascending: false)
             ],
             predicate: ZimFilesCategory.buildPredicate(
-                category: category.wrappedValue, searchText: searchText.wrappedValue
+                category: category.wrappedValue,
+                searchText: searchText.wrappedValue,
+                languageCode: selectedLanguage.wrappedValue
             ),
             animation: .easeInOut
         )
@@ -239,14 +263,7 @@ private struct CategoryList: View {
     var body: some View {
         Group {
             if zimFiles.isEmpty {
-                switch viewModel.state {
-                case .inProgress:
-                    Message(text: LocalString.zim_file_catalog_fetching_message)
-                case .error:
-                    Message(text: LocalString.library_refresh_error_retrieve_description, color: .red)
-                case .initial, .complete:
-                    Message(text: LocalString.zim_file_category_section_empty_message)
-                }
+                CategoryEmptySection()
             } else {
                 List(zimFiles, id: \.self, selection: $selection.selectedZimFile) { zimFile in
                     LibraryZimFileContext(
@@ -265,10 +282,25 @@ private struct CategoryList: View {
         .searchable(text: $searchText, prompt: LocalString.common_search)
         .onChange(of: category) { selection.reset() }
         .onChange(of: searchText) { _, newValue in
-            zimFiles.nsPredicate = ZimFilesCategory.buildPredicate(category: category, searchText: newValue)
+            zimFiles.nsPredicate = ZimFilesCategory
+                .buildPredicate(
+                    category: category,
+                    searchText: newValue,
+                    languageCode: selectedLanguage
+                )
+        }
+        .onChange(of: selectedLanguage) {
+            zimFiles.nsPredicate = ZimFilesCategory
+                .buildPredicate(
+                    category: category,
+                    searchText: searchText,
+                    languageCode: selectedLanguage
+                )
         }
         .onChange(of: languageCodes) {
-            zimFiles.nsPredicate = ZimFilesCategory.buildPredicate(category: category, searchText: searchText)
+            if !languageCodes.contains(selectedLanguage) {
+                selectedLanguage = languageCodes.first ?? "eng"
+            }
         }
     }
 }

--- a/Views/Library/ZimFilesNew.swift
+++ b/Views/Library/ZimFilesNew.swift
@@ -104,6 +104,7 @@ struct ZimFilesNew: View {
     @EnvironmentObject private var selection: SelectedZimFileViewModel
     @EnvironmentObject var library: LibraryViewModel
     @Default(.libraryLanguageCodes) private var languageCodes
+    @State private var selectedLanguage: String = Defaults[.libraryLanguageCodes].first ?? "eng"
     @StateObject private var viewModel = ViewModel()
     @State private var searchText = ""
     let dismiss: (() -> Void)? // iOS only
@@ -134,14 +135,19 @@ struct ZimFilesNew: View {
         .navigationTitle(MenuItem.new.name)
         .searchable(text: $searchText, prompt: LocalString.common_search)
         .task {
-            await viewModel.forceRefreshWith(searchText: searchText, languageCodes: languageCodes)
+            await viewModel.forceRefreshWith(searchText: searchText, languageCodes: [selectedLanguage])
             await library.start(isUserInitiated: false)
         }
         .onChange(of: searchText) { _, newSearchText in
             viewModel.update(searchText: newSearchText)
         }
-        .onChange(of: languageCodes) { _, newLanguageCodes in
-            viewModel.update(languageCodes: newLanguageCodes)
+        .onChange(of: selectedLanguage) {
+            viewModel.update(languageCodes: [selectedLanguage])
+        }
+        .onChange(of: languageCodes) {
+            if !languageCodes.contains(selectedLanguage) {
+                selectedLanguage = languageCodes.first ?? "eng"
+            }
         }
         .overlay {
             if viewModel.zimFiles.isEmpty {
@@ -156,12 +162,27 @@ struct ZimFilesNew: View {
             }
         }
         .toolbar {
-            ToolbarItem {
+#if os(iOS)
+            let languagePlacement: ToolbarItemPlacement = .topBarTrailing
+#else
+            let languagePlacement: ToolbarItemPlacement = .automatic
+#endif
+            ToolbarItem(placement: languagePlacement) {
+                if languageCodes.count > 1 {
+                    ToggleAroundLanguageButton(items: $languageCodes, selection: $selectedLanguage)
+                }
+            }
+#if os(iOS)
+            let refreshPlacement: ToolbarItemPlacement = .title
+#else
+            let refreshPlacement: ToolbarItemPlacement = .automatic
+#endif
+            ToolbarItem(placement: refreshPlacement) {
                 if library.state == .inProgress {
                     ProgressView()
-                    #if os(macOS)
+#if os(macOS)
                         .scaleEffect(0.5)
-                    #endif
+#endif
                 } else {
                     Button {
                         Task { [weak library] in

--- a/Views/Settings/Languages/LanguageSelector.swift
+++ b/Views/Settings/Languages/LanguageSelector.swift
@@ -105,7 +105,7 @@ struct LanguageSelector: View {
         }
 #if os(iOS)
         .listStyle(.insetGrouped)
-        .navigationTitle(LocalString.language_selector_navitation_title)
+        .navigationTitle(LocalString.settings_selected_language_title)
         .navigationBarTitleDisplayMode(.inline)
         .searchable(text: $searchText, isPresented: $isSearching, prompt: LocalString.common_search)
 #else


### PR DESCRIPTION
#### Fixes: #1633 

## Impact for end user
Now it is possible to filter down the list of items in the categories by selected language. The order of the languages is set in the app settings.

For users with a single language, there's no difference, since we won't display any additional buttons to filter.

## **iPhone**

https://github.com/user-attachments/assets/eb12f1c3-d40a-446f-af84-e1932bfb51c4

## **iPad**
https://github.com/user-attachments/assets/f973f39a-249e-4a0f-82e9-48742e26b3f9

## **mac**

https://github.com/user-attachments/assets/422ee1e9-19cf-4edb-ba33-825d7a9a31ac

