### PR TITLE
Fix ApplePayment button resolving on unsupported platforms

### DIFF
--- a/App/RootView_macOS.swift
+++ b/App/RootView_macOS.swift
@@ -25,7 +25,7 @@ struct RootView: View {
     @StateObject private var navigation = NavigationViewModel()
     @SceneStorage("org.kiwix.macos.root.menuitem") private var currentNavItem: MenuItem?
     @StateObject private var windowTracker = WindowTracker()
-    @State private var paymentButtonLabel: PayWithApplePayButtonLabel?
+    @State private var paymentButtonLabel: PaymentButtonType?
     var isSearchFocused: FocusState<Bool>.Binding
     @StateObject private var selection = SelectedZimFileViewModel()
     // Open file alerts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 3.17.0
 
+# 3.16.1
+- FIX:
+    - Apple pay button crash on unsupported platforms (@BPerlakiH #1653)
+
 # 3.16.0
 - NEW:
     - Recurring donation payments using apple pay email (@BPerlakiH #1579)

--- a/Model/Payment.swift
+++ b/Model/Payment.swift
@@ -145,17 +145,17 @@ struct Payment {
     /// - Returns: Setup button if no cards added yet,
     /// nil if Apple Pay is not supported
     /// or donation button, if all is OK
-    static private func paymentButtonType() -> ApplePaymentLabelType? {
+    static private func paymentButtonType() -> PaymentButtonType? {
         // only kiwix app is supporting donations atm.
         guard case .kiwix = AppType.current else { return nil }
         
         if PKPaymentAuthorizationController.canMakePayments() {
-            return ApplePaymentLabelType.donate
+            return PaymentButtonType.donate
         }
         if PKPaymentAuthorizationController.canMakePayments(
             usingNetworks: Payment.supportedNetworks,
             capabilities: Payment.capabilities) {
-            return ApplePaymentLabelType.setUp
+            return PaymentButtonType.setUp
         }
         return nil
     }
@@ -170,8 +170,8 @@ struct Payment {
     /// - Returns: Setup button if no cards added yet,
     /// nil if Apple Pay is not supported
     /// or donation button, if all is OK
-    static func paymentButtonTypeAsync() async -> PayWithApplePayButtonLabel? {
-        let task = Task<ApplePaymentLabelType?, Never>(priority: .low) {
+    static func paymentButtonTypeAsync() async -> PaymentButtonType? {
+        let task = Task<PaymentButtonType?, Never>(priority: .low) {
             Self.paymentButtonType()
         }
         guard let buttonLabel = await task.result.get() else {
@@ -179,9 +179,9 @@ struct Payment {
         }
         switch buttonLabel {
         case .donate:
-            return PayWithApplePayButtonLabel.donate
+            return PaymentButtonType.donate
         case .setUp:
-            return PayWithApplePayButtonLabel.setUp
+            return PaymentButtonType.setUp
         }
     }
 

--- a/Views/Payment/PaymentButtonType.swift
+++ b/Views/Payment/PaymentButtonType.swift
@@ -1,0 +1,26 @@
+// This file is part of Kiwix for iOS & macOS.
+//
+// Kiwix is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// any later version.
+//
+// Kiwix is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Kiwix; If not, see https://www.gnu.org/licenses/.
+
+import Foundation
+
+/// Intermediate represenation of PayWithApplePayButtonLabel
+/// which might crash on resolving directly in an async manner
+/// so we first resolve it to this type (optionally)
+/// and only if available trying to use PayWithApplePayButtonLabel
+/// see: https://github.com/kiwix/kiwix-apple/issues/1651
+enum PaymentButtonType {
+    case setUp
+    case donate
+}

--- a/Views/Payment/PaymentSummary.swift
+++ b/Views/Payment/PaymentSummary.swift
@@ -24,7 +24,7 @@ struct PaymentSummary: View {
     private let selectedAmount: SelectedAmount
     private let payment: Payment
     @State private var paymentDetermined: Bool = false
-    @State private var paymentButtonLabel: PayWithApplePayButtonLabel?
+    @State private var paymentButtonLabel: PaymentButtonType?
 
     init(selectedAmount: SelectedAmount) {
         self.selectedAmount = selectedAmount
@@ -56,8 +56,14 @@ struct PaymentSummary: View {
                 .bold()
             if paymentDetermined {
                 if let paymentButtonLabel {
+                    let label = {
+                        switch paymentButtonLabel {
+                        case .setUp: PayWithApplePayButtonLabel.setUp
+                        case .donate: PayWithApplePayButtonLabel.donate
+                        }
+                    }()
                     PayWithApplePayButton(
-                        paymentButtonLabel,
+                        label,
                         request: payment.donationRequest(for: selectedAmount),
                         onPaymentAuthorizationChange: { phase in
                             payment.onPaymentAuthPhase(selectedAmount: selectedAmount,

--- a/Views/Settings/Settings.swift
+++ b/Views/Settings/Settings.swift
@@ -162,7 +162,7 @@ struct Settings: View {
     @EnvironmentObject private var colorSchemeStore: UserColorSchemeStore
     @EnvironmentObject private var library: LibraryViewModel
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
-    @State private var paymentButtonLabel: PayWithApplePayButtonLabel?
+    @State private var paymentButtonLabel: PaymentButtonType?
     @Environment(\.dismiss) private var dismiss
 
     enum Route {

--- a/project.yml
+++ b/project.yml
@@ -113,7 +113,7 @@ targets:
         com.apple.developer.in-app-payments: [merchant.org.kiwix.apple] # this line is removed for macOS FTP
     settings:
       base:
-        MARKETING_VERSION: "3.16.0"
+        MARKETING_VERSION: "3.16.1"
         PRODUCT_BUNDLE_IDENTIFIER: self.Kiwix
         INFOPLIST_KEY_CFBundleDisplayName: Kiwix
         INFOPLIST_FILE: Support/Info.plist


### PR DESCRIPTION
#### Fixes: #1651, related to #1658

## Impact for end user
Application won't crash as checking the Apple Pay availability will be performed on an intermediate type.

### Tested on
- [x] **iPhone** simulator iOS 18.6, and it was crashing the same way as in the issue
- [x] **mac**, to make sure it compiles and shows the button
- [x] will do a testing on the reporter's mac as well