### PR TITLE
Update upload command method to app-store-connect

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -33,7 +33,7 @@ env:
   APPLE_STORE_AUTH_KEY_PATH: /tmp/authkey.p8
   APPLE_AUTH_PARAMS: "-authenticationKeyPath /tmp/authkey.p8 -authenticationKeyID ${{ secrets.APPLE_STORE_AUTH_KEY_ID }} -authenticationKeyIssuerID ${{ secrets.APPLE_STORE_AUTH_KEY_ISSUER_ID }}"
   # conditionally updated later:
-  EXPORT_METHOD: "app-store"
+  EXPORT_METHOD: "app-store-connect"
   EXTRA_XCODEBUILD: ""
   UPLOAD_TO: "" # !important this filters down the matrix combinations
   VERSION: ""


### PR DESCRIPTION
#### Fixes: #1653 

## Impact for end user
No impact, we should see the warning disappearing in our CD workflow logs.

### Can be tested on CD workflow (once merged).