### PR TITLE
Update to app version 3.17.0

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -113,7 +113,7 @@ targets:
         com.apple.developer.in-app-payments: [merchant.org.kiwix.apple] # this line is removed for macOS FTP
     settings:
       base:
-        MARKETING_VERSION: "3.16.1"
+        MARKETING_VERSION: "3.17.0"
         PRODUCT_BUNDLE_IDENTIFIER: self.Kiwix
         INFOPLIST_KEY_CFBundleDisplayName: Kiwix
         INFOPLIST_FILE: Support/Info.plist


### PR DESCRIPTION
Since the current 3.16.1 is already released / in review, we can update the project file to the next version.

## It should fix any CD issues
Since app store / test flight would not allow uploads with a version that has been already released.