### PR TITLE
Trail align language switcher on iPad under categories

### DIFF
--- a/App/SplitViewForiPad.swift
+++ b/App/SplitViewForiPad.swift
@@ -92,7 +92,7 @@ struct SplitViewForiPad: View { // swiftlint:disable:this type_body_length
                 case .categories:
                     ZimFilesCategories(languageCode: $selectedLang, dismiss: nil)
                         .toolbar {
-                            ToolbarItem(placement: .secondaryAction) {
+                            ToolbarItem(placement: .topBarTrailing) {
                                 ToggleAroundLanguageButton(items: $languages, selection: $selectedLang)
                             }
                         }


### PR DESCRIPTION
#### Fixes: #1660 

## Impact for end user
Consistent alignment of the language switcher button on iPad.


## Screenshots

<img width="1280" height="889" alt="Simulator Screenshot - iPad Air 11-inch (M4) - 2026-07-24 at 09 09 14 Large" src="https://github.com/user-attachments/assets/b5b1b74f-1385-41f8-92b8-0c1cf5c35c9d" />
<img width="1280" height="889" alt="Simulator Screenshot - iPad Air 11-inch (M4) - 2026-07-24 at 09 09 20 Large" src="https://github.com/user-attachments/assets/267a9c5a-3c90-4b8e-bf00-21914cd0e284" />


### Tested on
- [ ] **iPhone** - not affected
- [x] **iPad**
- [ ] **mac** - not affected