### PR TITLE
Persist hotspot selection

### DIFF
--- a/SwiftUI/Model/DefaultKeys.swift
+++ b/SwiftUI/Model/DefaultKeys.swift
@@ -53,6 +53,7 @@ extension Defaults.Keys {
     static let selectedCategory = Key<String?>("selectedCategory", default: nil)
     
     static let hotspotPortNumber = Key<Int>("hotspotPortNumber", default: Hotspot.defaultPort)
+    static let selectedHotspotIds = Key<Set<UUID>>("slectedHotspotIds", default: Set<UUID>())
     static let openZIMsShowBy = Key<ZIMsShowBy>("openZIMsShowBy", default: ZIMsShowBy.all)
     static let opneZIMsSorting = Key<ZIMsSortBy>("openZIMsSortBy", default: ZIMsSortBy.size(.forward))
 

--- a/ViewModel/ZimSelectionViewModels.swift
+++ b/ViewModel/ZimSelectionViewModels.swift
@@ -13,11 +13,36 @@
 // You should have received a copy of the GNU General Public License
 // along with Kiwix; If not, see https://www.gnu.org/licenses/.
 
+import Defaults
 import SwiftUI
 
 @MainActor
 final class MultiSelectedZimFilesViewModel: ObservableObject {
-    @Published private(set) var selectedZimFiles = Set<ZimFile>()
+    private let persistKey: Defaults.Key<Set<UUID>>?
+    
+    @Published private(set) var selectedZimFiles = Set<ZimFile>() {
+        didSet {
+            if let persistKey {
+                Defaults[persistKey] = Set(selectedZimFiles.map { $0.fileID })
+            }
+        }
+    }
+    
+    init(persistUsing: Defaults.Key<Set<UUID>>? = nil) {
+        guard FeatureFlags.hasLibrary, let persistUsing else {
+            persistKey = nil
+            return
+        }
+        persistKey = persistUsing
+        let savedIds = Defaults[persistUsing].sorted()
+        guard !savedIds.isEmpty else { return }
+        let fetchedZimFiles: [ZimFile] = Database.shared.viewContext.performAndWait {
+            let fetchRequest = ZimFile.fetchRequest(fileIDs: savedIds)
+            return try? fetchRequest.execute()
+        } ?? []
+        
+        selectedZimFiles = Set(fetchedZimFiles)
+    }
     
     func toggleMultiSelect(of zimFile: ZimFile) {
         guard FeatureFlags.hasLibrary else { return }

--- a/Views/Hotspot/HotspotObservable.swift
+++ b/Views/Hotspot/HotspotObservable.swift
@@ -13,11 +13,12 @@
 // You should have received a copy of the GNU General Public License
 // along with Kiwix; If not, see https://www.gnu.org/licenses/.
 
-import SwiftUI
 import Combine
+import Defaults
+import SwiftUI
 
 enum HotspotState: Equatable {
-    @MainActor static let selection = MultiSelectedZimFilesViewModel()
+    @MainActor static let selection = MultiSelectedZimFilesViewModel(persistUsing: .selectedHotspotIds)
     
     case started(URL, CGImage?)
     case stopped


### PR DESCRIPTION
#### Fixes: #1646

## Impact for end user
Selected ZIM files under the Hotspot section will be remembered, regardless if the hotspot service was started or not.

- Added:
Saving the UUIDs of the ZIM files into user defaults.
Using a a dynamic persistence key, since the same view model is re-used for multi ZIM file selection on macOS "Opened" section (see: multi select to unlink).
Non library based builds (branded apps) are excluded.

### Tested on
- [x] **iPhone**
- [x] **iPad**
- [x] **mac**