### PR TITLE
Save menu selection on iPad

### DIFF
--- a/App/App_iOS.swift
+++ b/App/App_iOS.swift
@@ -89,21 +89,6 @@ struct Kiwix: App {
                         NotificationCenter.openURL(url)
                     }
                 }
-                .task {
-                    switch AppType.current {
-                    case .kiwix:
-                        await LibraryOperations.reValidate()
-                        if !DeepLinkService.shared.isRunning() {
-                            navigation.navigateToMostRecentTab()
-                        }
-                        LibraryOperations.applyFileBackupSetting()
-                        DownloadService.shared.restartHeartbeatIfNeeded()
-                    case let .branded(zimFileURL):
-                        await LibraryOperations.open(url: zimFileURL)
-                        await ZimMigration.forCustomApps()
-                        navigation.navigateToMostRecentTab()
-                    }
-                }
                 .onAppear {
                     colorSchemeStore.update()
                 }

--- a/App/RootView_iOS.swift
+++ b/App/RootView_iOS.swift
@@ -14,17 +14,48 @@
 // along with Kiwix; If not, see https://www.gnu.org/licenses/.
 
 #if os(iOS)
-import SwiftUI
 import CoreData
+import Defaults
+import SwiftUI
 
 @MainActor
 struct RootViewiOS: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @EnvironmentObject private var navigation: NavigationViewModel
+    @Default(.savedMenuNavigation) private var selection: MenuItem?
+    
     var body: some View {
         if horizontalSizeClass == .compact {
             CompactView()
+                .task {
+                    await onStart(isCompact: true)
+                }
         } else {
             SplitViewForiPadContainer()
+                .task {
+                    await onStart(isCompact: false)
+                }
+        }
+    }
+    
+    private func onStart(isCompact: Bool) async {
+        switch AppType.current {
+        case .kiwix:
+            await LibraryOperations.reValidate()
+            let toRecentTab: Bool = isCompact || selection == nil
+            if !DeepLinkService.shared.isRunning(), toRecentTab {
+                navigation.navigateToMostRecentTab()
+            } else if let selection {
+                navigation.currentItem = selection.navigationItem
+            }
+            LibraryOperations.applyFileBackupSetting()
+            DownloadService.shared.restartHeartbeatIfNeeded()
+        case let .branded(zimFileURL):
+            await LibraryOperations.open(url: zimFileURL)
+            await ZimMigration.forCustomApps()
+            if !DeepLinkService.shared.isRunning() {
+                navigation.navigateToMostRecentTab()
+            }
         }
     }
 }

--- a/App/SplitViewForiPad.swift
+++ b/App/SplitViewForiPad.swift
@@ -39,7 +39,7 @@ struct SplitViewForiPad: View { // swiftlint:disable:this type_body_length
     @State private var columnVisibility: NavigationSplitViewVisibility = Defaults[.ipadSplitViewVisibility]
     @State private var allSections: [MenuSection] = MenuSection.allMenuSections
     @State private var menuDict: [MenuSection: [MenuItem]] = MenuSection.staticDictionary
-    @State private var selection: MenuItem?
+    @Default(.savedMenuNavigation) private var selection: MenuItem?
     @State private var languages = Defaults[.libraryLanguageCodes]
     @State private var selectedLang: String = Defaults[.libraryLanguageCodes].first ?? "eng"
     @State private var navPath = NavigationPath()
@@ -116,10 +116,13 @@ struct SplitViewForiPad: View { // swiftlint:disable:this type_body_length
             await observeHasZimFiles()
             await loadDonations()
             observeNavigateToHotspotSettings()
-            // set up the default selection
-            // as direct opening a file (when the app is not launched)
-            // won't trigger .onChange(of: navigation.currentItem)
-            if let currentItem = navigation.currentItem {
+            if let selection {
+                // restore navigation point from saved selection
+                navigation.currentItem = selection.navigationItem
+            } else if let currentItem = navigation.currentItem {
+                // set up the default selection
+                // as direct opening a file (when the app is not launched)
+                // won't trigger .onChange(of: navigation.currentItem)
                 selection = MenuItem(from: currentItem)
             }
             if case let .tab(selectedTabId) = selection {

--- a/SwiftUI/Model/DefaultKeys.swift
+++ b/SwiftUI/Model/DefaultKeys.swift
@@ -65,6 +65,7 @@ extension Defaults.Keys {
     #endif
     
     #if os(iOS)
+    static let savedMenuNavigation = Key<MenuItem?>("savedMenuNavigation", default: nil)
     static let ipadSplitViewVisibility = Key<NavigationSplitViewVisibility>(
         "ipadSplitViewVisibility",
         default: NavigationSplitViewVisibility.detailOnly

--- a/SwiftUI/Model/MenuItem.swift
+++ b/SwiftUI/Model/MenuItem.swift
@@ -14,10 +14,11 @@
 // along with Kiwix; If not, see https://www.gnu.org/licenses/.
 
 import CoreData
+import Defaults
 import Foundation
 import SwiftUI
 
-enum MenuItem: Hashable, Identifiable, RawRepresentable {
+enum MenuItem: Hashable, Identifiable, RawRepresentable, Defaults.Serializable {
     typealias RawValue = String
 
     init?(rawValue: String) {


### PR DESCRIPTION
#### Fixes: #1659 

## Impact for end user
The application will restore the menu selection from the last session.

## Screenshots

https://github.com/user-attachments/assets/33313eda-2901-4060-aecc-4d31e5606f5f




### Tested on
- [x] **iPhone** - not applicable, we don't want to restore overlays
- [x] **iPad**
- [x] **mac** - was already implemented (when system settings allow restoration)