### PR TITLE
Fix branded apps navigate to hotspot settings

### DIFF
--- a/SwiftUI/Patches.swift
+++ b/SwiftUI/Patches.swift
@@ -135,9 +135,7 @@ extension NotificationCenter {
     }
     
     static func navigateToHotspotSettings() {
-        if FeatureFlags.hasLibrary {
-            NotificationCenter.default.post(name: .navigateToHotspotSettings, object: nil, userInfo: nil)
-        }
+        NotificationCenter.default.post(name: .navigateToHotspotSettings, object: nil, userInfo: nil)
     }
 
     static func toggleSidebar() {


### PR DESCRIPTION
#### Fixes: #1668 

## Impact for end user
Button takes the user to settings as expected.

- Changed:
Removed the "HasLibrary" gating, since Branded also have Hotspot.

## Screenshots

https://github.com/user-attachments/assets/fa055085-b921-4a9f-9b47-ca2c35937096


### Tested on
- [ ] **iPhone**
- [ ] **iPad**
- [X] **mac**