### PR TITLE
1671 Fix crash on accessing fileID after download cancellation

### DIFF
--- a/Model/Downloads/DownloadService.swift
+++ b/Model/Downloads/DownloadService.swift
@@ -109,7 +109,7 @@ final class DownloadService {
             let errorMessage = LocalString.download_service_error_option_directory
             DownloadUI.showAlert(.downloadErrorZIM(zimFileID: zimFileID, errorMessage: errorMessage))
             task.cancel()
-            await downloadManager.deleteDownloadTaskAsync(zimFileID: zimFileID)
+            downloadManager.deleteDownloadTask(zimFileID: zimFileID)
             return
         }
         
@@ -155,7 +155,7 @@ final class DownloadService {
         if let task = downloadTasks.filter({ $0.taskDescription == zimFileID.uuidString }).first {
             task.cancel()
         }
-        await downloadManager.deleteDownloadTaskAsync(zimFileID: zimFileID)
+        downloadManager.deleteDownloadTask(zimFileID: zimFileID)
     }
     
     /// Pause a zim file download task

--- a/Model/Downloads/DownloadTaskManager.swift
+++ b/Model/Downloads/DownloadTaskManager.swift
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Kiwix; If not, see https://www.gnu.org/licenses/.
 
+import CoreData
 import Foundation
 
 @MainActor
@@ -30,22 +31,48 @@ struct DownloadTaskManager {
         }
     }
     
-    func deleteDownloadTaskAsync(zimFileID: UUID) async {
-        progress.resetFor(uuid: zimFileID)
-        await Database.shared.viewContext.perform {
+    private func deleteDownloadTaskAsync(zimFileID: UUID) async {
+        // What we really want is to update the ZimFile entry
+        // to indicate that it has no more ZimFile.downloadTask associated with it
+        // The UI relies on this fact in it's display hierarchy.
+        // Deleting the DownloadTask directly poorly propagates upwards to the ZimFile.
+        // So instead let's set ZimFile.downloadTask = nil, which instantly updates the UI,
+        // and then we can do the deletion of the DownloadTask itself
+        let downloadTaskObjectId: NSManagedObjectID? = await Database.shared.viewContext.perform {
             do {
-                let request = DownloadTask.fetchRequest(fileID: zimFileID)
-                request.fetchLimit = 1
-                guard let downloadTask = try request.execute().first else { return }
                 let context = Database.shared.viewContext
-                context.delete(downloadTask)
+                let zimRequest = ZimFile.fetchRequest(fileID: zimFileID)
+                zimRequest.fetchLimit = 1
+                let zimFile: ZimFile? = try context.fetch(zimRequest).first
+                let downloadTaskObjectId = zimFile?.downloadTask?.objectID
+                zimFile?.downloadTask = nil
                 try context.save()
+                return downloadTaskObjectId
             } catch {
-                let fileId = zimFileID.uuidString
-                let errorDesc = error.localizedDescription
+                let errorDesc = "\(zimFileID.uuidString), \(error.localizedDescription)"
                 Log.DownloadService.error(
-                    "Error deleting download task for: \(fileId, privacy: .public), \(errorDesc, privacy: .public)"
+                    "Could not set ZimFile's downloadTask to nil for: \(errorDesc, privacy: .public)"
                 )
+                return nil
+            }
+        }
+       
+        if let downloadTaskObjectId {
+            // Update the UI now
+            progress.resetFor(uuid: zimFileID)
+            
+            // Clean up the now orphaned DownloadTask
+            let context = Database.shared.viewContext
+            await context.perform {
+                do {
+                    try context.execute(NSBatchDeleteRequest(objectIDs: [downloadTaskObjectId]))
+                } catch {
+                    let fileId = zimFileID.uuidString
+                    let errorDesc = error.localizedDescription
+                    Log.DownloadService.error(
+                        "Error deleting download task for: \(fileId, privacy: .public), \(errorDesc, privacy: .public)"
+                    )
+                }
             }
         }
     }

--- a/Views/BuildingBlocks/DownloadTaskCell.swift
+++ b/Views/BuildingBlocks/DownloadTaskCell.swift
@@ -27,8 +27,10 @@ struct DownloadTaskCell: View {
     @State private var downloadNetworkState: DownloadTaskNetworkState = .online
 
     let downloadZimFile: ZimFile
+    private let zimFileID: UUID
     init(_ downloadZimFile: ZimFile) {
         self.downloadZimFile = downloadZimFile
+        self.zimFileID = downloadZimFile.fileID
     }
 
     var body: some View {
@@ -86,7 +88,7 @@ struct DownloadTaskCell: View {
         .clipShape(CellBackground.clipShapeRectangle)
         .onHover { self.isHovering = $0 }
         .onReceive(DownloadService.shared.progress.publisher) { states in
-            if !states.isEmpty, let state = states[downloadZimFile.fileID] {
+            if !states.isEmpty, let state = states[zimFileID] {
                 self.downloadState = state
             }
         }


### PR DESCRIPTION
#### Fixes: #1671 

## Impact for end user
Cancelling download tasks should not cause sporadic crashes any more.

## Description

- Changed:
Make sure deletion is not colliding with the UI update cycle
Rely on a copy of plain data where possible rather than CoreData references to properties, as CoreData can pull the plug on any of the ``@NSManaged`` properties on deletion.


### Tested on
- [x] **iPhone**
- [x] **iPad**
- [x] **mac**